### PR TITLE
Redesign tikz-editor into Photoshop-style workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ junit/
 tutorials/*_files/
 
 # trash
+.worktrees/
 .claude/
 .omc/
 CLAUDE.md

--- a/astro_docs/public/tikz-editor.css
+++ b/astro_docs/public/tikz-editor.css
@@ -1,9 +1,65 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+:root {
+  --bg-body: #0e1019;
+  --bg-surface: #141620;
+  --bg-canvas: #0c0e16;
+  --bg-panel: #111320;
+  --bg-input: #0c0e16;
+  --bg-hover: #1e2233;
+  --bg-active: #2e2b5a;
+  --border: #1e2233;
+  --border-input: #252a3a;
+  --border-active: #4f46b0;
+  --text: #c8ccd4;
+  --text-secondary: #6b7084;
+  --text-muted: #4a4f62;
+  --accent: #818cf8;
+  --accent-text: #a5b4fc;
+  --btn-bg: #1a1e2e;
+  --btn-border: #252a3a;
+  --btn-text: #8a8fa0;
+  --toggle-bg: #1e2744;
+  --toggle-border: #334670;
+  --toggle-text: #7dd3fc;
+  --grid-dot: #282d3e;
+  --node-stroke: #555;
+  --node-text: #c0c4d0;
+  --pdf-bg: white;
+}
+
+body.light {
+  --bg-body: #f4f5f7;
+  --bg-surface: #e4e5ea;
+  --bg-canvas: #ffffff;
+  --bg-panel: #edeef2;
+  --bg-input: #ffffff;
+  --bg-hover: #d8d9e0;
+  --bg-active: #dddaf0;
+  --border: #cccdd5;
+  --border-input: #b8b9c5;
+  --border-active: #7c75cc;
+  --text: #1a1b2e;
+  --text-secondary: #555670;
+  --text-muted: #888998;
+  --accent: #5b5fc7;
+  --accent-text: #4a4eaa;
+  --btn-bg: #dddee5;
+  --btn-border: #c4c5d0;
+  --btn-text: #555670;
+  --toggle-bg: #d5e4f5;
+  --toggle-border: #8ab4dd;
+  --toggle-text: #2a6ea8;
+  --grid-dot: #d0d1d9;
+  --node-stroke: #999;
+  --node-text: #333;
+  --pdf-bg: white;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  background: #0e1019;
-  color: #c8ccd4;
+  background: var(--bg-body);
+  color: var(--text);
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -17,8 +73,8 @@ body {
   align-items: center;
   gap: 0.4rem;
   padding: 0.35rem 0.75rem;
-  background: #141620;
-  border-bottom: 1px solid #1e2233;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
   min-height: 40px;
 }
@@ -26,7 +82,7 @@ body {
 .toolbar-brand {
   font-size: 0.85rem;
   font-weight: 700;
-  color: #818cf8;
+  color: var(--accent);
   margin-right: 0.75rem;
   white-space: nowrap;
 }
@@ -40,7 +96,7 @@ body {
 .toolbar-sep {
   width: 1px;
   height: 20px;
-  background: #1e2233;
+  background: var(--border);
   margin: 0 0.25rem;
   flex-shrink: 0;
 }
@@ -49,9 +105,9 @@ body {
 
 .tool-btn {
   padding: 0.3rem 0.6rem;
-  border: 1px solid #252a3a;
-  background: #1a1e2e;
-  color: #8a8fa0;
+  border: 1px solid var(--btn-border);
+  background: var(--btn-bg);
+  color: var(--btn-text);
   border-radius: 5px;
   cursor: pointer;
   font-size: 0.72rem;
@@ -59,10 +115,13 @@ body {
   transition: all 0.12s;
   white-space: nowrap;
   line-height: 1.2;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
 }
-.tool-btn:hover { background: #252a3a; color: #c8ccd4; }
-.tool-btn.active { background: #2e2b5a; border-color: #4f46b0; color: #a5b4fc; }
-.tool-btn.toggle.active { background: #1e2744; border-color: #334670; color: #7dd3fc; }
+.tool-btn:hover { background: var(--bg-hover); color: var(--text); }
+.tool-btn.active { background: var(--bg-active); border-color: var(--border-active); color: var(--accent-text); }
+.tool-btn.toggle.active { background: var(--toggle-bg); border-color: var(--toggle-border); color: var(--toggle-text); }
 .tool-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 .tool-btn.small { padding: 0.25rem 0.45rem; font-size: 0.75rem; min-width: 26px; text-align: center; }
 
@@ -78,7 +137,7 @@ body {
 }
 #zoom-level {
   font-size: 0.68rem;
-  color: #64687a;
+  color: var(--text-muted);
   min-width: 36px;
   text-align: center;
   user-select: none;
@@ -90,6 +149,58 @@ body {
   margin-left: 0.5rem;
   white-space: nowrap;
 }
+
+/* ── Left Toolbar ── */
+
+#left-toolbar {
+  width: 40px;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.4rem 0;
+  gap: 0;
+  flex-shrink: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.lt-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 0;
+}
+
+.lt-sep {
+  width: 24px;
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+  flex-shrink: 0;
+}
+
+.lt-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.12s;
+  padding: 0;
+}
+.lt-btn:hover { background: var(--bg-hover); color: var(--text); }
+.lt-btn.active { background: var(--bg-active); border-color: var(--border-active); color: var(--accent-text); }
+.lt-btn:disabled { opacity: 0.25; cursor: not-allowed; }
+.lt-btn:disabled:hover { background: transparent; color: var(--text-secondary); }
+.lt-btn svg { pointer-events: none; }
 
 /* ── Main layout ── */
 
@@ -103,7 +214,7 @@ body {
   flex: 1;
   position: relative;
   overflow: hidden;
-  background: #0c0e16;
+  background: var(--bg-canvas);
   cursor: default;
   min-width: 300px;
 }
@@ -118,19 +229,19 @@ body {
 
 #resizer {
   width: 4px;
-  background: #1a1e2e;
+  background: var(--btn-bg);
   cursor: col-resize;
   flex-shrink: 0;
   transition: background 0.12s;
 }
-#resizer:hover { background: #4f46b0; }
+#resizer:hover { background: var(--border-active); }
 
 #right-panel {
   width: 300px;
   display: flex;
   flex-direction: column;
-  background: #111320;
-  border-left: 1px solid #1e2233;
+  background: var(--bg-panel);
+  border-left: 1px solid var(--border);
   overflow: hidden;
 }
 
@@ -139,8 +250,8 @@ body {
 #tab-bar {
   display: flex;
   align-items: stretch;
-  background: #0c0e16;
-  border-bottom: 1px solid #1e2233;
+  background: var(--bg-canvas);
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
   overflow-x: auto;
   min-height: 32px;
@@ -155,7 +266,7 @@ body {
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  color: #555a6e;
+  color: var(--text-muted);
   cursor: pointer;
   font-size: 0.7rem;
   font-weight: 500;
@@ -164,9 +275,9 @@ body {
   user-select: none;
   transition: color 0.12s, background 0.12s;
 }
-.tab-btn:hover { color: #c8ccd4; background: #141620; }
-.tab-btn.active { color: #818cf8; border-bottom-color: #6366f1; background: #111320; }
-.tab-btn.drag-over { border-left: 2px solid #818cf8; }
+.tab-btn:hover { color: var(--text); background: var(--bg-surface); }
+.tab-btn.active { color: var(--accent); border-bottom-color: #6366f1; background: var(--bg-panel); }
+.tab-btn.drag-over { border-left: 2px solid var(--accent); }
 .tab-btn.dragging { opacity: 0.3; }
 
 .tab-hide-btn {
@@ -176,32 +287,32 @@ body {
   margin-left: 2px;
   background: none;
   border: none;
-  color: #3a3f52;
+  color: var(--text-muted);
   cursor: pointer;
   border-radius: 3px;
   pointer-events: all;
 }
-.tab-hide-btn:hover { color: #f87171; background: #1a1e2e; }
+.tab-hide-btn:hover { color: #f87171; background: var(--btn-bg); }
 
 #tab-restore-btn {
   margin-left: auto;
   padding: 0.2rem 0.4rem;
   background: none;
   border: none;
-  color: #3a3f52;
+  color: var(--text-muted);
   cursor: pointer;
   font-size: 0.9rem;
   align-self: center;
   flex-shrink: 0;
 }
-#tab-restore-btn:hover { color: #818cf8; }
+#tab-restore-btn:hover { color: var(--accent); }
 
 #tab-restore-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: #141620;
-  border: 1px solid #1e2233;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: 5px;
   z-index: 200;
   min-width: 120px;
@@ -213,12 +324,12 @@ body {
   padding: 0.35rem 0.65rem;
   background: none;
   border: none;
-  color: #c8ccd4;
+  color: var(--text);
   text-align: left;
   cursor: pointer;
   font-size: 0.72rem;
 }
-#tab-restore-menu button:hover { background: #1e2233; }
+#tab-restore-menu button:hover { background: var(--bg-hover); }
 
 /* ── Tab content ── */
 
@@ -236,7 +347,7 @@ body {
 
 .hint {
   font-size: 0.72rem;
-  color: #4a4f62;
+  color: var(--text-muted);
   line-height: 1.5;
 }
 
@@ -249,21 +360,21 @@ body {
 .prop-row label {
   width: 80px;
   font-size: 0.7rem;
-  color: #6b7084;
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 .prop-row input, .prop-row select {
   flex: 1;
-  background: #0c0e16;
-  border: 1px solid #252a3a;
-  color: #c8ccd4;
+  background: var(--bg-input);
+  border: 1px solid var(--border-input);
+  color: var(--text);
   border-radius: 4px;
   padding: 0.2rem 0.35rem;
   font-size: 0.72rem;
 }
 .prop-row input:focus, .prop-row select:focus {
   outline: none;
-  border-color: #4f46b0;
+  border-color: var(--border-active);
 }
 .prop-row input[type="color"] {
   padding: 0;
@@ -282,14 +393,14 @@ body {
   align-items: center;
   gap: 0.2rem;
   font-size: 0.66rem;
-  color: #6b7084;
+  color: var(--text-secondary);
   cursor: pointer;
   flex-shrink: 0;
 }
 
 .prop-group {
   margin-bottom: 0.2rem;
-  border: 1px solid #1a1e2e;
+  border: 1px solid var(--btn-bg);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -299,8 +410,8 @@ body {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #6b7084;
-  background: #141620;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
   cursor: pointer;
   user-select: none;
   list-style: none;
@@ -312,7 +423,7 @@ body {
 
 .prop-node-id {
   font-size: 0.72rem;
-  color: #818cf8;
+  color: var(--accent);
   display: block;
   margin-bottom: 0.4rem;
   font-weight: 600;
@@ -324,7 +435,7 @@ body {
 
 .code-fold {
   margin-bottom: 0.3rem;
-  border: 1px solid #1a1e2e;
+  border: 1px solid var(--btn-bg);
   border-radius: 4px;
   overflow: hidden;
 }
@@ -334,8 +445,8 @@ body {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #6b7084;
-  background: #0c0e16;
+  color: var(--text-secondary);
+  background: var(--bg-canvas);
   cursor: pointer;
   user-select: none;
   list-style: none;
@@ -352,20 +463,20 @@ body {
   font-family: 'Fira Code', 'SF Mono', 'Cascadia Code', monospace;
   font-size: 0.68rem;
   white-space: pre;
-  color: #a5b4fc;
+  color: var(--accent-text);
   line-height: 1.5;
 }
 
 .copy-btn {
   font-size: 0.66rem;
   padding: 0.15rem 0.4rem;
-  border: 1px solid #252a3a;
+  border: 1px solid var(--btn-border);
   background: transparent;
-  color: #6b7084;
+  color: var(--text-secondary);
   border-radius: 3px;
   cursor: pointer;
 }
-.copy-btn:hover { background: #1a1e2e; color: #c8ccd4; }
+.copy-btn:hover { background: var(--btn-bg); color: var(--text); }
 
 /* ── PDF pane ── */
 
@@ -403,21 +514,21 @@ body {
 
 #compile-log-details {
   margin-top: 0.2rem;
-  border: 1px solid #1a1e2e;
+  border: 1px solid var(--btn-bg);
   border-radius: 4px;
-  background: #0c0e16;
+  background: var(--bg-canvas);
 }
 #compile-log-details summary {
   padding: 0.25rem 0.5rem;
   font-size: 0.68rem;
-  color: #6b7084;
+  color: var(--text-secondary);
   cursor: pointer;
   user-select: none;
 }
 #compile-log {
   font-size: 0.65rem;
   font-family: monospace;
-  color: #6b7084;
+  color: var(--text-secondary);
   white-space: pre-wrap;
   word-break: break-all;
   padding: 0.4rem 0.6rem;
@@ -428,11 +539,12 @@ body {
 #compile-log.has-error { color: #fca5a5; }
 #compile-log .log-error { color: #f87171; font-weight: bold; }
 
-#pdf-canvas {
+#pdf-viewer {
   width: 100%;
-  border: 1px solid #252a3a;
+  min-height: 400px;
+  border: 1px solid var(--border-input);
   border-radius: 5px;
-  background: white;
+  background: var(--pdf-bg);
 }
 
 /* ── SVG canvas elements ── */
@@ -470,8 +582,8 @@ body {
   display: none;
   position: fixed;
   z-index: 1000;
-  background: #141620;
-  border: 1px solid #252a3a;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-input);
   border-radius: 6px;
   min-width: 160px;
   padding: 0.25rem 0;
@@ -484,24 +596,24 @@ body {
   padding: 0.35rem 0.75rem;
   background: none;
   border: none;
-  color: #c8ccd4;
+  color: var(--text);
   text-align: left;
   cursor: pointer;
   font-size: 0.72rem;
   font-family: inherit;
 }
-.ctx-item:hover { background: #1e2233; }
+.ctx-item:hover { background: var(--bg-hover); }
 .ctx-item.danger { color: #f87171; }
 .ctx-item.danger:hover { background: #2a1a1a; }
 .ctx-shortcut {
   float: right;
-  color: #4a4f62;
+  color: var(--text-muted);
   font-size: 0.65rem;
 }
 
 .ctx-sep {
   height: 1px;
-  background: #1e2233;
+  background: var(--border);
   margin: 0.2rem 0;
 }
 
@@ -510,8 +622,211 @@ body {
 #status-bar {
   font-size: 0.68rem;
   padding: 0.25rem 0.75rem;
-  color: #4a4f62;
-  background: #0c0e16;
-  border-top: 1px solid #1a1e2e;
+  color: var(--text-muted);
+  background: var(--bg-canvas);
+  border-top: 1px solid var(--btn-bg);
   flex-shrink: 0;
 }
+
+/* ── Template Gallery ── */
+
+#template-gallery {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  background: var(--bg-canvas);
+  padding: 2rem;
+}
+
+#template-gallery.hidden { display: none; }
+
+.tpl-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 0.3rem;
+}
+
+.tpl-subtitle {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-bottom: 1.5rem;
+}
+
+.tpl-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 160px);
+  gap: 0.75rem;
+  justify-content: center;
+  max-width: 720px;
+}
+
+.tpl-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.tpl-card:hover {
+  border-color: var(--accent);
+  background: var(--bg-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+}
+
+.tpl-card svg {
+  width: 120px;
+  height: 70px;
+}
+
+.tpl-card-name {
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.tpl-card-desc {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  text-align: center;
+  line-height: 1.3;
+}
+
+/* ── Layers Panel ── */
+
+.layer-row {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.35rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.72rem;
+  transition: background 0.1s;
+  border: 1px solid transparent;
+}
+.layer-row:hover { background: var(--bg-hover); }
+.layer-row.active-layer { background: var(--bg-active); border-color: var(--border-active); }
+
+.layer-vis-btn, .layer-lock-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.72rem;
+  padding: 2px 4px;
+  border-radius: 3px;
+  line-height: 1;
+}
+.layer-vis-btn:hover, .layer-lock-btn:hover { background: var(--bg-hover); color: var(--text); }
+.layer-vis-btn.hidden-layer { opacity: 0.35; }
+.layer-lock-btn.locked-layer { color: #f59e0b; }
+
+.layer-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+}
+
+.layer-count {
+  font-size: 0.62rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.layer-actions {
+  display: flex;
+  gap: 0.3rem;
+  padding: 0.4rem 0;
+  margin-top: 0.3rem;
+  border-top: 1px solid var(--border);
+}
+
+.layer-action-btn {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.66rem;
+  background: var(--btn-bg);
+  border: 1px solid var(--btn-border);
+  color: var(--btn-text);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.layer-action-btn:hover { background: var(--bg-hover); color: var(--text); }
+
+/* ── Raw TikZ ── */
+
+#raw-tikz-input {
+  width: 100%;
+  min-height: 60px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-input);
+  color: var(--accent-text);
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+  font-family: 'Fira Code', 'SF Mono', 'Cascadia Code', monospace;
+  font-size: 0.68rem;
+  line-height: 1.5;
+  resize: vertical;
+  margin: 0;
+}
+#raw-tikz-input:focus {
+  outline: none;
+  border-color: var(--border-active);
+}
+
+/* ── Multi-select ── */
+
+.multi-select-info {
+  font-size: 0.72rem;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 0.4rem;
+  font-weight: 600;
+}
+
+.batch-btn {
+  padding: 0.3rem 0.5rem;
+  font-size: 0.68rem;
+  background: var(--btn-bg);
+  border: 1px solid var(--btn-border);
+  color: var(--btn-text);
+  border-radius: 4px;
+  cursor: pointer;
+  margin-right: 0.3rem;
+  margin-bottom: 0.3rem;
+}
+.batch-btn:hover { background: var(--bg-hover); color: var(--text); }
+.batch-btn.danger { color: #f87171; border-color: #5a2020; }
+.batch-btn.danger:hover { background: #2a1a1a; }
+
+/* ── Selection marquee ── */
+
+#selection-marquee {
+  position: absolute;
+  border: 1px solid var(--accent);
+  background: rgba(129, 140, 248, 0.08);
+  pointer-events: none;
+  z-index: 60;
+  display: none;
+}
+
+/* ── Export button ── */
+
+#btn-export-tex {
+  background: #1a2433 !important;
+  border-color: #2a4060 !important;
+  color: #7dd3fc !important;
+}
+#btn-export-tex:hover { background: #2a4060 !important; }

--- a/astro_docs/public/tikz-editor.css
+++ b/astro_docs/public/tikz-editor.css
@@ -1,44 +1,97 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: system-ui, sans-serif;
-  background: #1a1a2e;
-  color: #e0e0e0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  background: #0e1019;
+  color: #c8ccd4;
   height: 100vh;
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
 
+/* ── Toolbar ── */
+
 #toolbar {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: #16213e;
-  border-bottom: 1px solid #0f3460;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  background: #141620;
+  border-bottom: 1px solid #1e2233;
+  flex-shrink: 0;
+  min-height: 40px;
+}
+
+.toolbar-brand {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #818cf8;
+  margin-right: 0.75rem;
+  white-space: nowrap;
+}
+
+.toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.toolbar-sep {
+  width: 1px;
+  height: 20px;
+  background: #1e2233;
+  margin: 0 0.25rem;
   flex-shrink: 0;
 }
 
-#toolbar h1 {
-  font-size: 1rem;
-  font-weight: 700;
-  color: #a78bfa;
-  margin-right: 1rem;
-}
+.toolbar-spacer { flex: 1; }
 
 .tool-btn {
-  padding: 0.35rem 0.8rem;
-  border: 1px solid #4c1d95;
-  background: #2d1b69;
-  color: #e0e0e0;
-  border-radius: 6px;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid #252a3a;
+  background: #1a1e2e;
+  color: #8a8fa0;
+  border-radius: 5px;
   cursor: pointer;
-  font-size: 0.8rem;
-  transition: background 0.15s;
+  font-size: 0.72rem;
+  font-weight: 500;
+  transition: all 0.12s;
+  white-space: nowrap;
+  line-height: 1.2;
 }
-.tool-btn:hover { background: #4c1d95; }
-.tool-btn.active { background: #7c3aed; border-color: #a78bfa; }
+.tool-btn:hover { background: #252a3a; color: #c8ccd4; }
+.tool-btn.active { background: #2e2b5a; border-color: #4f46b0; color: #a5b4fc; }
+.tool-btn.toggle.active { background: #1e2744; border-color: #334670; color: #7dd3fc; }
+.tool-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+.tool-btn.small { padding: 0.25rem 0.45rem; font-size: 0.75rem; min-width: 26px; text-align: center; }
+
+.compile-btn {
+  background: #1a2e24 !important;
+  border-color: #234d36 !important;
+  color: #6ee7b7 !important;
+}
+.compile-btn:hover { background: #234d36 !important; }
+
+.zoom-group {
+  gap: 0.15rem;
+}
+#zoom-level {
+  font-size: 0.68rem;
+  color: #64687a;
+  min-width: 36px;
+  text-align: center;
+  user-select: none;
+}
+
+#pyodide-status {
+  font-size: 0.68rem;
+  color: #a78025;
+  margin-left: 0.5rem;
+  white-space: nowrap;
+}
+
+/* ── Main layout ── */
 
 #main {
   display: flex;
@@ -50,121 +103,125 @@ body {
   flex: 1;
   position: relative;
   overflow: hidden;
-  background: #0d1117;
+  background: #0c0e16;
   cursor: default;
+  min-width: 300px;
 }
-
 #canvas-area.mode-node { cursor: crosshair; }
 #canvas-area.mode-edge { cursor: cell; }
-
-#canvas-area { min-width: 300px; }
-
-#resizer {
-  width: 5px;
-  background: #0f3460;
-  cursor: col-resize;
-  flex-shrink: 0;
-  transition: background 0.15s;
-}
-#resizer:hover { background: #7c3aed; }
 
 #svg-canvas {
   width: 100%;
   height: 100%;
+  display: block;
 }
 
-#svg-canvas { background-image: radial-gradient(circle, #2a2a4a 1px, transparent 1px); background-size: 30px 30px; }
+#resizer {
+  width: 4px;
+  background: #1a1e2e;
+  cursor: col-resize;
+  flex-shrink: 0;
+  transition: background 0.12s;
+}
+#resizer:hover { background: #4f46b0; }
 
 #right-panel {
-  width: 320px;
+  width: 300px;
   display: flex;
   flex-direction: column;
-  background: #16213e;
-  border-left: 1px solid #0f3460;
+  background: #111320;
+  border-left: 1px solid #1e2233;
   overflow: hidden;
 }
 
 /* ── Tab bar ── */
+
 #tab-bar {
   display: flex;
   align-items: stretch;
-  background: #0d1117;
-  border-bottom: 2px solid #0f3460;
+  background: #0c0e16;
+  border-bottom: 1px solid #1e2233;
   flex-shrink: 0;
   overflow-x: auto;
-  min-height: 34px;
+  min-height: 32px;
   position: relative;
 }
+
 .tab-btn {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.3rem 0.55rem;
+  gap: 0.2rem;
+  padding: 0.25rem 0.5rem;
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  color: #64748b;
+  color: #555a6e;
   cursor: pointer;
-  font-size: 0.76rem;
+  font-size: 0.7rem;
+  font-weight: 500;
   white-space: nowrap;
-  margin-bottom: -2px;
+  margin-bottom: -1px;
   user-select: none;
-  transition: color 0.15s, background 0.15s;
+  transition: color 0.12s, background 0.12s;
 }
-.tab-btn:hover { color: #e0e0e0; background: #16213e; }
-.tab-btn.active { color: #a78bfa; border-bottom-color: #7c3aed; background: #16213e; }
-.tab-btn.drag-over { border-left: 2px solid #a78bfa; }
-.tab-btn.dragging { opacity: 0.35; }
+.tab-btn:hover { color: #c8ccd4; background: #141620; }
+.tab-btn.active { color: #818cf8; border-bottom-color: #6366f1; background: #111320; }
+.tab-btn.drag-over { border-left: 2px solid #818cf8; }
+.tab-btn.dragging { opacity: 0.3; }
+
 .tab-hide-btn {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   line-height: 1;
   padding: 1px 3px;
   margin-left: 2px;
   background: none;
   border: none;
-  color: #475569;
+  color: #3a3f52;
   cursor: pointer;
   border-radius: 3px;
   pointer-events: all;
 }
-.tab-hide-btn:hover { color: #f87171; background: #1e293b; }
+.tab-hide-btn:hover { color: #f87171; background: #1a1e2e; }
+
 #tab-restore-btn {
   margin-left: auto;
-  padding: 0.2rem 0.5rem;
+  padding: 0.2rem 0.4rem;
   background: none;
   border: none;
-  color: #475569;
+  color: #3a3f52;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 0.9rem;
   align-self: center;
   flex-shrink: 0;
 }
-#tab-restore-btn:hover { color: #a78bfa; }
+#tab-restore-btn:hover { color: #818cf8; }
+
 #tab-restore-menu {
   position: absolute;
   top: 100%;
   right: 0;
-  background: #1a1a3e;
-  border: 1px solid #0f3460;
-  border-radius: 4px;
+  background: #141620;
+  border: 1px solid #1e2233;
+  border-radius: 5px;
   z-index: 200;
-  min-width: 130px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+  min-width: 120px;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.5);
 }
 #tab-restore-menu button {
   display: block;
   width: 100%;
-  padding: 0.4rem 0.75rem;
+  padding: 0.35rem 0.65rem;
   background: none;
   border: none;
-  color: #e0e0e0;
+  color: #c8ccd4;
   text-align: left;
   cursor: pointer;
-  font-size: 0.78rem;
+  font-size: 0.72rem;
 }
-#tab-restore-menu button:hover { background: #16213e; }
+#tab-restore-menu button:hover { background: #1e2233; }
 
-/* ── Tab content area ── */
+/* ── Tab content ── */
+
 #tab-content {
   flex: 1;
   overflow-y: auto;
@@ -173,133 +230,112 @@ body {
 .tab-pane { display: none; flex-direction: column; }
 .tab-pane.active-pane { display: flex; }
 
-/* ── PDF pane ── */
-#pdf-pane-inner {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.75rem;
-}
-#pdf-download {
-  font-size: 0.78rem;
-  color: #6ee7b7;
-  text-decoration: none;
-  padding: 0.3rem 0.6rem;
-  border: 1px solid #047857;
-  border-radius: 4px;
-  background: #065f46;
-  align-self: flex-start;
-}
+/* ── Properties ── */
 
-#compile-log-details {
-  margin-top: 0.25rem;
-  border: 1px solid #1e3a5f;
-  border-radius: 4px;
-  background: #0d1117;
-}
-#compile-log-details summary {
-  padding: 0.3rem 0.6rem;
-  font-size: 0.75rem;
-  color: #94a3b8;
-  cursor: pointer;
-  user-select: none;
-}
-#compile-log-details summary:hover { color: #e0e0e0; }
-#compile-log {
-  font-size: 0.7rem;
-  font-family: monospace;
-  color: #94a3b8;
-  white-space: pre-wrap;
-  word-break: break-all;
-  padding: 0.5rem 0.75rem;
-  max-height: 300px;
-  overflow-y: auto;
-  margin: 0;
-}
-#compile-log.has-error { color: #fca5a5; }
-#compile-log .log-error { color: #f87171; font-weight: bold; }
+.panel-body { padding: 0.6rem; }
 
-.color-none-wrap {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
+.hint {
   font-size: 0.72rem;
-  color: #94a3b8;
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
-.panel-section {
-  border-bottom: 1px solid #0f3460;
-  overflow: visible;
-}
-
-.panel-header {
-  padding: 0.5rem 1rem;
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #a78bfa;
-  background: #1a1a3e;
-  cursor: pointer;
-  user-select: none;
-  display: flex;
-  justify-content: space-between;
-}
-
-.panel-body {
-  padding: 0.75rem;
+  color: #4a4f62;
+  line-height: 1.5;
 }
 
 .prop-row {
   display: flex;
   align-items: center;
-  margin-bottom: 0.5rem;
-  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+  gap: 0.4rem;
+}
+.prop-row label {
+  width: 80px;
+  font-size: 0.7rem;
+  color: #6b7084;
+  flex-shrink: 0;
+}
+.prop-row input, .prop-row select {
+  flex: 1;
+  background: #0c0e16;
+  border: 1px solid #252a3a;
+  color: #c8ccd4;
+  border-radius: 4px;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.72rem;
+}
+.prop-row input:focus, .prop-row select:focus {
+  outline: none;
+  border-color: #4f46b0;
+}
+.prop-row input[type="color"] {
+  padding: 0;
+  height: 26px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.prop-row input[type="checkbox"] {
+  flex: none;
+  width: 14px;
+  height: 14px;
 }
 
-.prop-row label {
-  width: 90px;
-  font-size: 0.78rem;
-  color: #94a3b8;
+.color-none-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.66rem;
+  color: #6b7084;
+  cursor: pointer;
   flex-shrink: 0;
 }
 
-.prop-row input, .prop-row select {
-  flex: 1;
-  background: #0d1117;
-  border: 1px solid #334155;
-  color: #e0e0e0;
+.prop-group {
+  margin-bottom: 0.2rem;
+  border: 1px solid #1a1e2e;
   border-radius: 4px;
-  padding: 0.25rem 0.4rem;
-  font-size: 0.8rem;
+  overflow: hidden;
 }
-
-.prop-row input[type="color"] {
-  padding: 0;
-  height: 28px;
+.prop-group > summary {
+  padding: 0.25rem 0.45rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7084;
+  background: #141620;
   cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+.prop-group > summary::-webkit-details-marker { display: none; }
+.prop-group > summary::before { content: '\25B8  '; }
+.prop-group[open] > summary::before { content: '\25BE  '; }
+.prop-group > .prop-group-body { padding: 0.3rem 0.4rem; }
+
+.prop-node-id {
+  font-size: 0.72rem;
+  color: #818cf8;
+  display: block;
+  margin-bottom: 0.4rem;
+  font-weight: 600;
 }
 
-#code-output {
-  padding: 0.75rem;
-}
+/* ── Code panel ── */
+
+#code-output { padding: 0.6rem; }
 
 .code-fold {
-  margin-bottom: 0.4rem;
-  border: 1px solid #1e293b;
+  margin-bottom: 0.3rem;
+  border: 1px solid #1a1e2e;
   border-radius: 4px;
   overflow: hidden;
 }
 .code-fold > summary {
-  padding: 0.3rem 0.5rem;
-  font-size: 0.7rem;
-  font-weight: 700;
+  padding: 0.25rem 0.45rem;
+  font-size: 0.65rem;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #94a3b8;
-  background: #0d1117;
+  color: #6b7084;
+  background: #0c0e16;
   cursor: pointer;
   user-select: none;
   list-style: none;
@@ -308,137 +344,174 @@ body {
   justify-content: space-between;
 }
 .code-fold > summary::-webkit-details-marker { display: none; }
-.code-fold > summary::before { content: '▸ '; flex-shrink: 0; }
-.code-fold[open] > summary::before { content: '▾ '; }
-.code-fold > pre { margin: 0; padding: 0.5rem 0.75rem; overflow-x: auto; }
+.code-fold > summary::before { content: '\25B8  '; flex-shrink: 0; }
+.code-fold[open] > summary::before { content: '\25BE  '; }
+.code-fold > pre { margin: 0; padding: 0.4rem 0.6rem; overflow-x: auto; }
 
 #python-code, #tikz-code {
-  font-family: 'Fira Code', 'Cascadia Code', monospace;
-  font-size: 0.72rem;
+  font-family: 'Fira Code', 'SF Mono', 'Cascadia Code', monospace;
+  font-size: 0.68rem;
   white-space: pre;
-  color: #a5f3fc;
+  color: #a5b4fc;
   line-height: 1.5;
-  margin-bottom: 0.5rem;
 }
 
 .copy-btn {
-  font-size: 0.72rem;
-  padding: 0.2rem 0.5rem;
-  border: 1px solid #334155;
+  font-size: 0.66rem;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid #252a3a;
   background: transparent;
-  color: #94a3b8;
-  border-radius: 4px;
+  color: #6b7084;
+  border-radius: 3px;
   cursor: pointer;
-  margin-bottom: 0.5rem;
 }
-.copy-btn:hover { background: #1e293b; }
+.copy-btn:hover { background: #1a1e2e; color: #c8ccd4; }
 
-#compile-btn {
-  padding: 0.45rem;
-  width: 100%;
-  background: #065f46;
-  color: #6ee7b7;
-  border: 1px solid #047857;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 0.82rem;
-  font-weight: 600;
-}
-#compile-btn:hover { background: #047857; }
-#compile-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+/* ── PDF pane ── */
 
-#pdf-section {
-  flex: 1;
+#pdf-pane-inner {
   display: flex;
   flex-direction: column;
-  padding: 0.75rem;
-  min-height: 0;
+  gap: 0.4rem;
+  padding: 0.6rem;
 }
+
+#compile-btn {
+  padding: 0.4rem;
+  width: 100%;
+  background: #1a2e24;
+  color: #6ee7b7;
+  border: 1px solid #234d36;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 0.76rem;
+  font-weight: 600;
+}
+#compile-btn:hover { background: #234d36; }
+#compile-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+#pdf-download {
+  font-size: 0.72rem;
+  color: #6ee7b7;
+  text-decoration: none;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #234d36;
+  border-radius: 4px;
+  background: #1a2e24;
+  align-self: flex-start;
+}
+
+#compile-log-details {
+  margin-top: 0.2rem;
+  border: 1px solid #1a1e2e;
+  border-radius: 4px;
+  background: #0c0e16;
+}
+#compile-log-details summary {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.68rem;
+  color: #6b7084;
+  cursor: pointer;
+  user-select: none;
+}
+#compile-log {
+  font-size: 0.65rem;
+  font-family: monospace;
+  color: #6b7084;
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: 0.4rem 0.6rem;
+  max-height: 280px;
+  overflow-y: auto;
+  margin: 0;
+}
+#compile-log.has-error { color: #fca5a5; }
+#compile-log .log-error { color: #f87171; font-weight: bold; }
 
 #pdf-canvas {
   width: 100%;
-  border: 1px solid #334155;
-  border-radius: 6px;
+  border: 1px solid #252a3a;
+  border-radius: 5px;
   background: white;
 }
 
-#status-bar {
-  font-size: 0.72rem;
-  padding: 0.3rem 0.75rem;
-  color: #64748b;
-  background: #0d1117;
-  border-top: 1px solid #0f3460;
-  flex-shrink: 0;
-}
+/* ── SVG canvas elements ── */
 
-.tikz-node rect, .tikz-node circle, .tikz-node ellipse {
-  stroke-width: 1.5;
+.tikz-node rect, .tikz-node circle, .tikz-node ellipse, .tikz-node polygon {
   cursor: grab;
+  transition: filter 0.1s;
 }
 .tikz-node.selected rect,
 .tikz-node.selected circle,
-.tikz-node.selected ellipse {
-  stroke-width: 3;
-  filter: drop-shadow(0 0 6px #a78bfa);
+.tikz-node.selected ellipse,
+.tikz-node.selected polygon {
+  filter: drop-shadow(0 0 5px rgba(129,140,248,0.5));
+}
+.tikz-node.edge-source rect,
+.tikz-node.edge-source circle,
+.tikz-node.edge-source ellipse,
+.tikz-node.edge-source polygon {
+  stroke: #fbbf24 !important;
+  stroke-width: 2 !important;
 }
 .tikz-node text {
   pointer-events: none;
   user-select: none;
-  font-size: 12px;
-  fill: #e0e0e0;
-  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
 }
 
-.tikz-edge {
-  stroke-width: 1.5;
-  fill: none;
+.tikz-edge { fill: none; cursor: pointer; }
+.tikz-edge.selected { filter: drop-shadow(0 0 3px rgba(129,140,248,0.4)); }
+
+/* ── Context menu ── */
+
+#context-menu {
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  background: #141620;
+  border: 1px solid #252a3a;
+  border-radius: 6px;
+  min-width: 160px;
+  padding: 0.25rem 0;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+}
+
+.ctx-item {
+  display: block;
+  width: 100%;
+  padding: 0.35rem 0.75rem;
+  background: none;
+  border: none;
+  color: #c8ccd4;
+  text-align: left;
   cursor: pointer;
-}
-.tikz-edge.selected {
-  stroke-width: 3;
-  filter: drop-shadow(0 0 4px #a78bfa);
-}
-
-.tikz-node.edge-source rect,
-.tikz-node.edge-source circle,
-.tikz-node.edge-source ellipse {
-  stroke: #fbbf24 !important;
-  stroke-width: 3;
-}
-
-#pyodide-status {
   font-size: 0.72rem;
-  color: #fbbf24;
+  font-family: inherit;
+}
+.ctx-item:hover { background: #1e2233; }
+.ctx-item.danger { color: #f87171; }
+.ctx-item.danger:hover { background: #2a1a1a; }
+.ctx-shortcut {
+  float: right;
+  color: #4a4f62;
+  font-size: 0.65rem;
 }
 
-/* ── Node property groups (collapsible <details>) ── */
-.prop-group {
-  margin-bottom: 0.3rem;
-  border: 1px solid #1e293b;
-  border-radius: 4px;
-  overflow: hidden;
+.ctx-sep {
+  height: 1px;
+  background: #1e2233;
+  margin: 0.2rem 0;
 }
-.prop-group > summary {
-  padding: 0.3rem 0.5rem;
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: #a78bfa;
-  background: #1a1a3e;
-  cursor: pointer;
-  user-select: none;
-  list-style: none;
-}
-.prop-group > summary::-webkit-details-marker { display: none; }
-.prop-group > summary::before { content: '▸ '; }
-.prop-group[open] > summary::before { content: '▾ '; }
-.prop-group > .prop-group-body { padding: 0.3rem 0.4rem; }
 
-/* ── Toolbar compile button ── */
-.compile-toolbar-btn {
-  background: #065f46 !important;
-  border-color: #047857 !important;
-  color: #6ee7b7 !important;
+/* ── Status bar ── */
+
+#status-bar {
+  font-size: 0.68rem;
+  padding: 0.25rem 0.75rem;
+  color: #4a4f62;
+  background: #0c0e16;
+  border-top: 1px solid #1a1e2e;
+  flex-shrink: 0;
 }
-.compile-toolbar-btn:hover { background: #047857 !important; }

--- a/astro_docs/public/tikz-editor.css
+++ b/astro_docs/public/tikz-editor.css
@@ -26,6 +26,9 @@
   --node-stroke: #555;
   --node-text: #c0c4d0;
   --pdf-bg: white;
+  --inspector-header-bg: #181b2a;
+  --drawer-bg: #111320;
+  --drawer-border: #1e2233;
 }
 
 body.light {
@@ -54,6 +57,9 @@ body.light {
   --node-stroke: #999;
   --node-text: #333;
   --pdf-bg: white;
+  --inspector-header-bg: #dddee8;
+  --drawer-bg: #edeef2;
+  --drawer-border: #cccdd5;
 }
 
 body {
@@ -132,9 +138,7 @@ body {
 }
 .compile-btn:hover { background: #234d36 !important; }
 
-.zoom-group {
-  gap: 0.15rem;
-}
+.zoom-group { gap: 0.15rem; }
 #zoom-level {
   font-size: 0.68rem;
   color: var(--text-muted);
@@ -160,7 +164,6 @@ body {
   flex-direction: column;
   align-items: center;
   padding: 0.4rem 0;
-  gap: 0;
   flex-shrink: 0;
   overflow-y: auto;
   overflow-x: hidden;
@@ -172,14 +175,6 @@ body {
   align-items: center;
   gap: 2px;
   padding: 2px 0;
-}
-
-.lt-sep {
-  width: 24px;
-  height: 1px;
-  background: var(--border);
-  margin: 4px 0;
-  flex-shrink: 0;
 }
 
 .lt-btn {
@@ -210,13 +205,23 @@ body {
   overflow: hidden;
 }
 
+/* ── Canvas column ── */
+
+#canvas-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 300px;
+}
+
 #canvas-area {
   flex: 1;
   position: relative;
   overflow: hidden;
   background: var(--bg-canvas);
   cursor: default;
-  min-width: 300px;
+  min-height: 200px;
 }
 #canvas-area.mode-node { cursor: crosshair; }
 #canvas-area.mode-edge { cursor: cell; }
@@ -227,214 +232,64 @@ body {
   display: block;
 }
 
-#resizer {
-  width: 4px;
+/* ── Drawer resize handle ── */
+
+#canvas-resizer {
+  height: 4px;
   background: var(--btn-bg);
-  cursor: col-resize;
+  cursor: row-resize;
   flex-shrink: 0;
   transition: background 0.12s;
 }
-#resizer:hover { background: var(--border-active); }
+#canvas-resizer:hover { background: var(--border-active); }
 
-#right-panel {
-  width: 300px;
+/* ── Bottom Drawer ── */
+
+#drawer {
+  height: 200px;
   display: flex;
   flex-direction: column;
-  background: var(--bg-panel);
-  border-left: 1px solid var(--border);
+  background: var(--drawer-bg);
+  border-top: 1px solid var(--drawer-border);
+  flex-shrink: 0;
   overflow: hidden;
 }
 
-/* ── Tab bar ── */
-
-#tab-bar {
+#drawer-tabs {
   display: flex;
-  align-items: stretch;
-  background: var(--bg-canvas);
+  gap: 0.25rem;
+  padding: 0.3rem 0.5rem;
+  background: var(--bg-surface);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
-  overflow-x: auto;
-  min-height: 32px;
-  position: relative;
 }
 
-.tab-btn {
-  display: flex;
-  align-items: center;
-  gap: 0.2rem;
-  padding: 0.25rem 0.5rem;
+.drawer-tab {
+  padding: 0.2rem 0.65rem;
+  border: 1px solid transparent;
   background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
   color: var(--text-muted);
+  border-radius: 99px;
   cursor: pointer;
   font-size: 0.7rem;
   font-weight: 500;
-  white-space: nowrap;
-  margin-bottom: -1px;
-  user-select: none;
-  transition: color 0.12s, background 0.12s;
+  transition: all 0.12s;
 }
-.tab-btn:hover { color: var(--text); background: var(--bg-surface); }
-.tab-btn.active { color: var(--accent); border-bottom-color: #6366f1; background: var(--bg-panel); }
-.tab-btn.drag-over { border-left: 2px solid var(--accent); }
-.tab-btn.dragging { opacity: 0.3; }
+.drawer-tab:hover { color: var(--text); background: var(--bg-hover); }
+.drawer-tab.active { background: var(--bg-active); border-color: var(--border-active); color: var(--accent-text); }
 
-.tab-hide-btn {
-  font-size: 0.7rem;
-  line-height: 1;
-  padding: 1px 3px;
-  margin-left: 2px;
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  border-radius: 3px;
-  pointer-events: all;
-}
-.tab-hide-btn:hover { color: #f87171; background: var(--btn-bg); }
-
-#tab-restore-btn {
-  margin-left: auto;
-  padding: 0.2rem 0.4rem;
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  font-size: 0.9rem;
-  align-self: center;
-  flex-shrink: 0;
-}
-#tab-restore-btn:hover { color: var(--accent); }
-
-#tab-restore-menu {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  z-index: 200;
-  min-width: 120px;
-  box-shadow: 0 6px 20px rgba(0,0,0,0.5);
-}
-#tab-restore-menu button {
-  display: block;
-  width: 100%;
-  padding: 0.35rem 0.65rem;
-  background: none;
-  border: none;
-  color: var(--text);
-  text-align: left;
-  cursor: pointer;
-  font-size: 0.72rem;
-}
-#tab-restore-menu button:hover { background: var(--bg-hover); }
-
-/* ── Tab content ── */
-
-#tab-content {
+.drawer-section {
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-}
-.tab-pane { display: none; flex-direction: column; }
-.tab-pane.active-pane { display: flex; }
-
-/* ── Properties ── */
-
-.panel-body { padding: 0.6rem; }
-
-.hint {
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-
-.prop-row {
-  display: flex;
-  align-items: center;
-  margin-bottom: 0.4rem;
-  gap: 0.4rem;
-}
-.prop-row label {
-  width: 80px;
-  font-size: 0.7rem;
-  color: var(--text-secondary);
-  flex-shrink: 0;
-}
-.prop-row input, .prop-row select {
-  flex: 1;
-  background: var(--bg-input);
-  border: 1px solid var(--border-input);
-  color: var(--text);
-  border-radius: 4px;
-  padding: 0.2rem 0.35rem;
-  font-size: 0.72rem;
-}
-.prop-row input:focus, .prop-row select:focus {
-  outline: none;
-  border-color: var(--border-active);
-}
-.prop-row input[type="color"] {
-  padding: 0;
-  height: 26px;
-  cursor: pointer;
-  border-radius: 4px;
-}
-.prop-row input[type="checkbox"] {
-  flex: none;
-  width: 14px;
-  height: 14px;
-}
-
-.color-none-wrap {
-  display: flex;
-  align-items: center;
-  gap: 0.2rem;
-  font-size: 0.66rem;
-  color: var(--text-secondary);
-  cursor: pointer;
-  flex-shrink: 0;
-}
-
-.prop-group {
-  margin-bottom: 0.2rem;
-  border: 1px solid var(--btn-bg);
-  border-radius: 4px;
-  overflow: hidden;
-}
-.prop-group > summary {
-  padding: 0.25rem 0.45rem;
-  font-size: 0.65rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-secondary);
-  background: var(--bg-surface);
-  cursor: pointer;
-  user-select: none;
-  list-style: none;
-}
-.prop-group > summary::-webkit-details-marker { display: none; }
-.prop-group > summary::before { content: '\25B8  '; }
-.prop-group[open] > summary::before { content: '\25BE  '; }
-.prop-group > .prop-group-body { padding: 0.3rem 0.4rem; }
-
-.prop-node-id {
-  font-size: 0.72rem;
-  color: var(--accent);
-  display: block;
-  margin-bottom: 0.4rem;
-  font-weight: 600;
+  padding: 0.5rem 0.6rem;
 }
 
 /* ── Code panel ── */
 
-#code-output { padding: 0.6rem; }
+#code-output { display: flex; flex-direction: column; gap: 0.3rem; }
 
 .code-fold {
-  margin-bottom: 0.3rem;
   border: 1px solid var(--btn-bg);
   border-radius: 4px;
   overflow: hidden;
@@ -478,13 +333,30 @@ body {
 }
 .copy-btn:hover { background: var(--btn-bg); color: var(--text); }
 
+/* ── Raw TikZ ── */
+
+#raw-tikz-input {
+  width: 100%;
+  min-height: 60px;
+  height: 100%;
+  background: var(--bg-input);
+  border: 1px solid var(--border-input);
+  color: var(--accent-text);
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+  font-family: 'Fira Code', 'SF Mono', 'Cascadia Code', monospace;
+  font-size: 0.68rem;
+  line-height: 1.5;
+  resize: none;
+}
+#raw-tikz-input:focus { outline: none; border-color: var(--border-active); }
+
 /* ── PDF pane ── */
 
 #pdf-pane-inner {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  padding: 0.6rem;
 }
 
 #compile-btn {
@@ -513,7 +385,6 @@ body {
 }
 
 #compile-log-details {
-  margin-top: 0.2rem;
   border: 1px solid var(--btn-bg);
   border-radius: 4px;
   background: var(--bg-canvas);
@@ -532,7 +403,7 @@ body {
   white-space: pre-wrap;
   word-break: break-all;
   padding: 0.4rem 0.6rem;
-  max-height: 280px;
+  max-height: 200px;
   overflow-y: auto;
   margin: 0;
 }
@@ -541,165 +412,133 @@ body {
 
 #pdf-viewer {
   width: 100%;
-  min-height: 400px;
+  min-height: 300px;
   border: 1px solid var(--border-input);
   border-radius: 5px;
   background: var(--pdf-bg);
 }
 
-/* ── SVG canvas elements ── */
+/* ── Right Panel (Inspector) ── */
 
-.tikz-node rect, .tikz-node circle, .tikz-node ellipse, .tikz-node polygon {
-  cursor: grab;
-  transition: filter 0.1s;
-}
-.tikz-node.selected rect,
-.tikz-node.selected circle,
-.tikz-node.selected ellipse,
-.tikz-node.selected polygon {
-  filter: drop-shadow(0 0 5px rgba(129,140,248,0.5));
-}
-.tikz-node.edge-source rect,
-.tikz-node.edge-source circle,
-.tikz-node.edge-source ellipse,
-.tikz-node.edge-source polygon {
-  stroke: #fbbf24 !important;
-  stroke-width: 2 !important;
-}
-.tikz-node text {
-  pointer-events: none;
-  user-select: none;
-  font-size: 11px;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-}
-
-.tikz-edge { fill: none; cursor: pointer; }
-.tikz-edge.selected { filter: drop-shadow(0 0 3px rgba(129,140,248,0.4)); }
-
-/* ── Context menu ── */
-
-#context-menu {
-  display: none;
-  position: fixed;
-  z-index: 1000;
-  background: var(--bg-surface);
-  border: 1px solid var(--border-input);
-  border-radius: 6px;
-  min-width: 160px;
-  padding: 0.25rem 0;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
-}
-
-.ctx-item {
-  display: block;
-  width: 100%;
-  padding: 0.35rem 0.75rem;
-  background: none;
-  border: none;
-  color: var(--text);
-  text-align: left;
-  cursor: pointer;
-  font-size: 0.72rem;
-  font-family: inherit;
-}
-.ctx-item:hover { background: var(--bg-hover); }
-.ctx-item.danger { color: #f87171; }
-.ctx-item.danger:hover { background: #2a1a1a; }
-.ctx-shortcut {
-  float: right;
-  color: var(--text-muted);
-  font-size: 0.65rem;
-}
-
-.ctx-sep {
-  height: 1px;
-  background: var(--border);
-  margin: 0.2rem 0;
-}
-
-/* ── Status bar ── */
-
-#status-bar {
-  font-size: 0.68rem;
-  padding: 0.25rem 0.75rem;
-  color: var(--text-muted);
-  background: var(--bg-canvas);
-  border-top: 1px solid var(--btn-bg);
+#right-panel {
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+  border-left: 1px solid var(--border);
+  overflow-y: auto;
+  overflow-x: hidden;
   flex-shrink: 0;
 }
 
-/* ── Template Gallery ── */
+/* ── Inspector Cards (Photoshop-style) ── */
 
-#template-gallery {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  z-index: 50;
-  background: var(--bg-canvas);
-  padding: 2rem;
+.inspector-card {
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
 }
 
-#template-gallery.hidden { display: none; }
-
-.tpl-title {
-  font-size: 1.1rem;
+.inspector-card-header {
+  display: flex;
+  align-items: center;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.65rem;
   font-weight: 700;
-  color: var(--text);
-  margin-bottom: 0.3rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  background: var(--inspector-header-bg);
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+  gap: 0.4rem;
 }
-
-.tpl-subtitle {
-  font-size: 0.78rem;
+.inspector-card-header::-webkit-details-marker { display: none; }
+.inspector-card-header::before {
+  content: '\25B8';
+  font-size: 0.6rem;
   color: var(--text-muted);
-  margin-bottom: 1.5rem;
+}
+.inspector-card[open] .inspector-card-header::before { content: '\25BE'; }
+
+.inspector-card-body {
+  padding: 0.5rem;
 }
 
-.tpl-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, 160px);
-  gap: 0.75rem;
-  justify-content: center;
-  max-width: 720px;
+/* ── Properties panel ── */
+
+.panel-body { padding: 0.6rem; }
+
+.hint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  line-height: 1.5;
 }
 
-.tpl-card {
+.prop-row {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
-  padding: 1rem 0.75rem;
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  margin-bottom: 0.4rem;
+  gap: 0.4rem;
+}
+.prop-row label {
+  width: 80px;
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+.prop-row input, .prop-row select {
+  flex: 1;
+  background: var(--bg-input);
+  border: 1px solid var(--border-input);
+  color: var(--text);
+  border-radius: 4px;
+  padding: 0.2rem 0.35rem;
+  font-size: 0.72rem;
+}
+.prop-row input:focus, .prop-row select:focus { outline: none; border-color: var(--border-active); }
+.prop-row input[type="color"] { padding: 0; height: 26px; cursor: pointer; border-radius: 4px; }
+.prop-row input[type="checkbox"] { flex: none; width: 14px; height: 14px; }
+
+.color-none-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.66rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.prop-group {
+  margin-bottom: 0.2rem;
+  border: 1px solid var(--btn-bg);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.prop-group > summary {
+  padding: 0.25rem 0.45rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
   background: var(--bg-surface);
   cursor: pointer;
-  transition: all 0.15s;
+  user-select: none;
+  list-style: none;
 }
-.tpl-card:hover {
-  border-color: var(--accent);
-  background: var(--bg-hover);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
-}
+.prop-group > summary::-webkit-details-marker { display: none; }
+.prop-group > summary::before { content: '\25B8  '; }
+.prop-group[open] > summary::before { content: '\25BE  '; }
+.prop-group > .prop-group-body { padding: 0.3rem 0.4rem; }
 
-.tpl-card svg {
-  width: 120px;
-  height: 70px;
-}
-
-.tpl-card-name {
-  font-size: 0.76rem;
+.prop-node-id {
+  font-size: 0.72rem;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 0.4rem;
   font-weight: 600;
-  color: var(--text);
-}
-
-.tpl-card-desc {
-  font-size: 0.65rem;
-  color: var(--text-muted);
-  text-align: center;
-  line-height: 1.3;
 }
 
 /* ── Layers Panel ── */
@@ -744,6 +583,10 @@ body {
   font-size: 0.62rem;
   color: var(--text-muted);
   flex-shrink: 0;
+  background: var(--bg-surface);
+  padding: 1px 5px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
 }
 
 .layer-actions {
@@ -764,27 +607,6 @@ body {
   cursor: pointer;
 }
 .layer-action-btn:hover { background: var(--bg-hover); color: var(--text); }
-
-/* ── Raw TikZ ── */
-
-#raw-tikz-input {
-  width: 100%;
-  min-height: 60px;
-  background: var(--bg-input);
-  border: 1px solid var(--border-input);
-  color: var(--accent-text);
-  border-radius: 4px;
-  padding: 0.4rem 0.6rem;
-  font-family: 'Fira Code', 'SF Mono', 'Cascadia Code', monospace;
-  font-size: 0.68rem;
-  line-height: 1.5;
-  resize: vertical;
-  margin: 0;
-}
-#raw-tikz-input:focus {
-  outline: none;
-  border-color: var(--border-active);
-}
 
 /* ── Multi-select ── */
 
@@ -811,6 +633,204 @@ body {
 .batch-btn.danger { color: #f87171; border-color: #5a2020; }
 .batch-btn.danger:hover { background: #2a1a1a; }
 
+/* ── SVG canvas elements ── */
+
+.tikz-node rect, .tikz-node circle, .tikz-node ellipse, .tikz-node polygon {
+  cursor: grab;
+  transition: filter 0.1s;
+}
+.tikz-node.selected rect,
+.tikz-node.selected circle,
+.tikz-node.selected ellipse,
+.tikz-node.selected polygon { filter: drop-shadow(0 0 5px rgba(129,140,248,0.5)); }
+.tikz-node.edge-source rect,
+.tikz-node.edge-source circle,
+.tikz-node.edge-source ellipse,
+.tikz-node.edge-source polygon { stroke: #fbbf24 !important; stroke-width: 2 !important; }
+.tikz-node text {
+  pointer-events: none;
+  user-select: none;
+  font-size: 11px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+}
+
+.tikz-edge { fill: none; cursor: pointer; }
+.tikz-edge.selected { filter: drop-shadow(0 0 3px rgba(129,140,248,0.4)); }
+
+/* ── Context menu ── */
+
+#context-menu {
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-input);
+  border-radius: 6px;
+  min-width: 160px;
+  padding: 0.25rem 0;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+}
+
+.ctx-item {
+  display: block;
+  width: 100%;
+  padding: 0.35rem 0.75rem;
+  background: none;
+  border: none;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-family: inherit;
+}
+.ctx-item:hover { background: var(--bg-hover); }
+.ctx-item.danger { color: #f87171; }
+.ctx-item.danger:hover { background: #2a1a1a; }
+.ctx-shortcut { float: right; color: var(--text-muted); font-size: 0.65rem; }
+
+.ctx-sep { height: 1px; background: var(--border); margin: 0.2rem 0; }
+
+/* ── Status bar ── */
+
+#status-bar {
+  font-size: 0.68rem;
+  padding: 0.25rem 0.75rem;
+  color: var(--text-muted);
+  background: var(--bg-canvas);
+  border-top: 1px solid var(--btn-bg);
+  flex-shrink: 0;
+}
+
+/* ── Compile Dialog ── */
+
+#compile-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.55);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#compile-dialog {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-input);
+  border-radius: 8px;
+  min-width: 300px;
+  max-width: 420px;
+  box-shadow: 0 12px 40px rgba(0,0,0,0.6);
+  overflow: hidden;
+}
+
+.dialog-title {
+  padding: 0.75rem 1rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
+  background: var(--inspector-header-bg);
+}
+
+#compile-dialog-layers {
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.dialog-layer-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.76rem;
+  color: var(--text);
+  cursor: pointer;
+}
+.dialog-layer-row input[type="checkbox"] {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.dialog-footer button {
+  padding: 0.3rem 0.8rem;
+  border-radius: 5px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid var(--btn-border);
+  background: var(--btn-bg);
+  color: var(--btn-text);
+}
+.dialog-footer button:hover { background: var(--bg-hover); color: var(--text); }
+.dialog-compile-btn {
+  background: #1a2e24 !important;
+  border-color: #234d36 !important;
+  color: #6ee7b7 !important;
+}
+.dialog-compile-btn:hover { background: #234d36 !important; }
+.dialog-compile-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ── Template Gallery ── */
+
+#template-gallery {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  background: var(--bg-canvas);
+  padding: 2rem;
+}
+#template-gallery.hidden { display: none; }
+
+.tpl-title { font-size: 1.1rem; font-weight: 700; color: var(--text); margin-bottom: 0.3rem; }
+.tpl-subtitle { font-size: 0.78rem; color: var(--text-muted); margin-bottom: 1.5rem; }
+
+.tpl-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 160px);
+  gap: 0.75rem;
+  justify-content: center;
+  max-width: 720px;
+}
+
+.tpl-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.tpl-card:hover {
+  border-color: var(--accent);
+  background: var(--bg-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+}
+.tpl-card svg { width: 120px; height: 70px; }
+.tpl-card-name { font-size: 0.76rem; font-weight: 600; color: var(--text); }
+.tpl-card-desc { font-size: 0.65rem; color: var(--text-muted); text-align: center; line-height: 1.3; }
+
 /* ── Selection marquee ── */
 
 #selection-marquee {
@@ -823,7 +843,6 @@ body {
 }
 
 /* ── Export button ── */
-
 #btn-export-tex {
   background: #1a2433 !important;
   border-color: #2a4060 !important;

--- a/astro_docs/public/tikz-editor.html
+++ b/astro_docs/public/tikz-editor.html
@@ -3,36 +3,65 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>TikZ Interactive Editor</title>
+  <title>TikZ Interactive Editor — tikzfigure</title>
   <link rel="stylesheet" href="/tikzfigure/tikz-editor.css">
 </head>
 <body>
 
 <div id="toolbar">
-  <h1>TikZ Editor</h1>
-  <button class="tool-btn active" id="btn-select" title="Select / Move (V)">Select (V)</button>
-  <button class="tool-btn" id="btn-add-node" title="Add Node (N)">+ Node (N)</button>
-  <button class="tool-btn" id="btn-add-edge" title="Add Edge (E)">+ Edge (E)</button>
-  <button class="tool-btn" id="btn-delete" title="Delete selected (Del)">Delete (Del)</button>
-  <button class="tool-btn" id="btn-clear" title="Clear all">Clear</button>
-  <button class="tool-btn compile-toolbar-btn" id="btn-compile-toolbar" title="Compile to PDF">⚡ PDF</button>
-  <span style="flex:1"></span>
-  <span id="pyodide-status">Loading Pyodide…</span>
+  <span class="toolbar-brand">TikZ Editor</span>
+  <div class="toolbar-group">
+    <button class="tool-btn active" id="btn-select" title="Select / Move (V)">Select</button>
+    <button class="tool-btn" id="btn-add-node" title="Add Node (N)">Node</button>
+    <button class="tool-btn" id="btn-add-edge" title="Add Edge (E)">Edge</button>
+  </div>
+  <div class="toolbar-sep"></div>
+  <div class="toolbar-group">
+    <button class="tool-btn" id="btn-undo" title="Undo (Ctrl+Z)" disabled>Undo</button>
+    <button class="tool-btn" id="btn-redo" title="Redo (Ctrl+Shift+Z)" disabled>Redo</button>
+  </div>
+  <div class="toolbar-sep"></div>
+  <div class="toolbar-group">
+    <button class="tool-btn" id="btn-duplicate" title="Duplicate (Ctrl+D)">Duplicate</button>
+    <button class="tool-btn" id="btn-delete" title="Delete (Del)">Delete</button>
+    <button class="tool-btn" id="btn-clear" title="Clear all">Clear</button>
+  </div>
+  <div class="toolbar-sep"></div>
+  <div class="toolbar-group">
+    <button class="tool-btn toggle active" id="btn-grid" title="Toggle Grid (G)">Grid</button>
+    <button class="tool-btn toggle active" id="btn-snap" title="Toggle Snap">Snap</button>
+  </div>
+  <div class="toolbar-sep"></div>
+  <div class="toolbar-group zoom-group">
+    <button class="tool-btn small" id="btn-zoom-out" title="Zoom Out">&minus;</button>
+    <span id="zoom-level">100%</span>
+    <button class="tool-btn small" id="btn-zoom-in" title="Zoom In">+</button>
+    <button class="tool-btn small" id="btn-zoom-reset" title="Reset View">Fit</button>
+  </div>
+  <span class="toolbar-spacer"></span>
+  <button class="tool-btn compile-btn" id="btn-compile-toolbar" title="Compile to PDF">PDF</button>
+  <span id="pyodide-status">Loading Pyodide...</span>
 </div>
 
 <div id="main">
   <div id="canvas-area" class="mode-select">
     <svg id="svg-canvas">
       <defs>
+        <pattern id="grid-dots" width="20" height="20" patternUnits="userSpaceOnUse">
+          <circle cx="10" cy="10" r="0.6" fill="#282d3e"/>
+        </pattern>
         <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-          <polygon points="0 0, 10 3.5, 0 7" fill="#94a3b8" />
+          <polygon points="0 0, 10 3.5, 0 7" fill="context-stroke"/>
         </marker>
-        <marker id="arrowhead-selected" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-          <polygon points="0 0, 10 3.5, 0 7" fill="#a78bfa" />
+        <marker id="arrowhead-sel" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+          <polygon points="0 0, 10 3.5, 0 7" fill="#818cf8"/>
         </marker>
       </defs>
-      <g id="edges-layer"></g>
-      <g id="nodes-layer"></g>
+      <g id="world">
+        <rect id="grid-bg" x="-5000" y="-5000" width="10000" height="10000" fill="url(#grid-dots)"/>
+        <g id="edges-layer"></g>
+        <g id="nodes-layer"></g>
+      </g>
     </svg>
   </div>
 
@@ -41,13 +70,11 @@
   <div id="right-panel">
     <div id="tab-bar"></div>
     <div id="tab-content">
-
       <div id="tab-pane-props" class="tab-pane">
         <div class="panel-body" id="properties-panel">
-          <p style="font-size:0.78rem;color:#64748b;">Select a node or edge to edit its properties.</p>
+          <p class="hint">Select a node or edge to edit properties.</p>
         </div>
       </div>
-
       <div id="tab-pane-code" class="tab-pane">
         <div id="code-output">
           <details class="code-fold" open>
@@ -60,11 +87,10 @@
           </details>
         </div>
       </div>
-
       <div id="tab-pane-pdf" class="tab-pane">
         <div id="pdf-pane-inner">
-          <button id="compile-btn" disabled>⚡ Compile to PDF (latex-on-http)</button>
-          <a id="pdf-download" style="display:none;" download="figure.pdf">⬇ Download / Open PDF</a>
+          <button id="compile-btn" disabled>Compile to PDF (latex-on-http)</button>
+          <a id="pdf-download" style="display:none;" download="figure.pdf">Download PDF</a>
           <canvas id="pdf-canvas" style="display:none;"></canvas>
           <details id="compile-log-details" style="display:none;">
             <summary>Compilation log</summary>
@@ -72,12 +98,13 @@
           </details>
         </div>
       </div>
-
     </div>
   </div>
 </div>
 
-<div id="status-bar">Ready. Click canvas in Node mode to add nodes.</div>
+<div id="context-menu"></div>
+
+<div id="status-bar">Ready. Press N to add nodes, E for edges, V to select. Scroll to zoom, middle-click to pan.</div>
 
 <script src="https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/build/pdf.min.js"></script>

--- a/astro_docs/public/tikz-editor.html
+++ b/astro_docs/public/tikz-editor.html
@@ -11,6 +11,20 @@
 <div id="toolbar">
   <span class="toolbar-brand">TikZ Editor</span>
   <div class="toolbar-sep"></div>
+  <div class="toolbar-group">
+    <button class="tool-btn compile-btn" id="btn-compile-toolbar" title="Compile to PDF">PDF</button>
+    <button class="tool-btn" id="btn-export-tex" title="Download .tex file">TEX</button>
+  </div>
+  <div class="toolbar-sep"></div>
+  <div class="toolbar-group">
+    <button class="tool-btn" id="btn-undo" title="Undo (Ctrl+Z)" disabled>
+      <svg viewBox="0 0 16 16" width="14" height="14"><path d="M5 7l-3-3 3-3" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M2 4h8a4 4 0 010 8H6" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+    </button>
+    <button class="tool-btn" id="btn-redo" title="Redo (Ctrl+Shift+Z)" disabled>
+      <svg viewBox="0 0 16 16" width="14" height="14"><path d="M11 7l3-3-3-3" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M14 4H6a4 4 0 000 8h4" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+    </button>
+  </div>
+  <div class="toolbar-sep"></div>
   <div class="toolbar-group zoom-group">
     <button class="tool-btn small" id="btn-zoom-out" title="Zoom Out">&minus;</button>
     <span id="zoom-level">100%</span>
@@ -27,8 +41,6 @@
     <svg id="theme-icon-dark" viewBox="0 0 16 16" width="14" height="14"><path d="M8 1a7 7 0 100 14A7 7 0 008 1zm0 12.5a5.5 5.5 0 010-11v11z" fill="currentColor"/></svg>
     <svg id="theme-icon-light" viewBox="0 0 16 16" width="14" height="14" style="display:none"><circle cx="8" cy="8" r="3.5" fill="currentColor"/><g stroke="currentColor" stroke-width="1.5"><line x1="8" y1="0.5" x2="8" y2="3"/><line x1="8" y1="13" x2="8" y2="15.5"/><line x1="0.5" y1="8" x2="3" y2="8"/><line x1="13" y1="8" x2="15.5" y2="8"/><line x1="2.7" y1="2.7" x2="4.5" y2="4.5"/><line x1="11.5" y1="11.5" x2="13.3" y2="13.3"/><line x1="2.7" y1="13.3" x2="4.5" y2="11.5"/><line x1="11.5" y1="4.5" x2="13.3" y2="2.7"/></g></svg>
   </button>
-  <button class="tool-btn compile-btn" id="btn-compile-toolbar" title="Compile to PDF">PDF</button>
-  <button class="tool-btn" id="btn-export-tex" title="Download .tex file">TEX</button>
   <span id="pyodide-status">Loading Pyodide...</span>
 </div>
 
@@ -45,63 +57,41 @@
         <svg viewBox="0 0 16 16" width="16" height="16"><path d="M2 14l3-1 8-8-2-2-8 8z" fill="none" stroke="currentColor" stroke-width="1.5"/><circle cx="13" cy="3" r="1.5" fill="currentColor"/></svg>
       </button>
     </div>
-    <div class="lt-sep"></div>
-    <div class="lt-group">
-      <button class="lt-btn" id="btn-undo" title="Undo (Ctrl+Z)" disabled>
-        <svg viewBox="0 0 16 16" width="16" height="16"><path d="M5 7l-3-3 3-3" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M2 4h8a4 4 0 010 8H6" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
-      </button>
-      <button class="lt-btn" id="btn-redo" title="Redo (Ctrl+Shift+Z)" disabled>
-        <svg viewBox="0 0 16 16" width="16" height="16"><path d="M11 7l3-3-3-3" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M14 4H6a4 4 0 000 8h4" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
-      </button>
-    </div>
-    <div class="lt-sep"></div>
-    <div class="lt-group">
-      <button class="lt-btn" id="btn-duplicate" title="Duplicate (Ctrl+D)">
-        <svg viewBox="0 0 16 16" width="16" height="16"><rect x="5" y="5" width="8" height="8" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/><rect x="3" y="3" width="8" height="8" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
-      </button>
-      <button class="lt-btn" id="btn-delete" title="Delete (Del)">
-        <svg viewBox="0 0 16 16" width="16" height="16"><path d="M4 4h8l-1 10H5zM3 4h10M6 2h4" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
-      </button>
-      <button class="lt-btn" id="btn-clear" title="Clear All">
-        <svg viewBox="0 0 16 16" width="16" height="16"><circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M5.5 5.5l5 5M10.5 5.5l-5 5" stroke="currentColor" stroke-width="1.5"/></svg>
-      </button>
-    </div>
   </div>
 
-  <div id="canvas-area" class="mode-select">
-    <svg id="svg-canvas">
-      <defs>
-        <pattern id="grid-dots" width="20" height="20" patternUnits="userSpaceOnUse">
-          <circle cx="10" cy="10" r="0.6" fill="#282d3e"/>
-        </pattern>
-        <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-          <polygon points="0 0, 10 3.5, 0 7" fill="context-stroke"/>
-        </marker>
-        <marker id="arrowhead-sel" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-          <polygon points="0 0, 10 3.5, 0 7" fill="#818cf8"/>
-        </marker>
-      </defs>
-      <g id="world">
-        <rect id="grid-bg" x="-5000" y="-5000" width="10000" height="10000" fill="url(#grid-dots)"/>
-        <g id="edges-layer"></g>
-        <g id="nodes-layer"></g>
-      </g>
-    </svg>
-    <div id="template-gallery"></div>
-    <div id="selection-marquee"></div>
-  </div>
+  <div id="canvas-column">
+    <div id="canvas-area" class="mode-select">
+      <svg id="svg-canvas">
+        <defs>
+          <pattern id="grid-dots" width="20" height="20" patternUnits="userSpaceOnUse">
+            <circle cx="10" cy="10" r="0.6" fill="#282d3e"/>
+          </pattern>
+          <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="context-stroke"/>
+          </marker>
+          <marker id="arrowhead-sel" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#818cf8"/>
+          </marker>
+        </defs>
+        <g id="world">
+          <rect id="grid-bg" x="-5000" y="-5000" width="10000" height="10000" fill="url(#grid-dots)"/>
+          <g id="edges-layer"></g>
+          <g id="nodes-layer"></g>
+        </g>
+      </svg>
+      <div id="template-gallery"></div>
+      <div id="selection-marquee"></div>
+    </div>
 
-  <div id="resizer"></div>
+    <div id="canvas-resizer"></div>
 
-  <div id="right-panel">
-    <div id="tab-bar"></div>
-    <div id="tab-content">
-      <div id="tab-pane-props" class="tab-pane">
-        <div class="panel-body" id="properties-panel">
-          <p class="hint">Select a node or edge to edit properties.</p>
-        </div>
+    <div id="drawer">
+      <div id="drawer-tabs">
+        <button class="drawer-tab active" data-section="code">Code</button>
+        <button class="drawer-tab" data-section="rawtikz">Raw TikZ</button>
+        <button class="drawer-tab" data-section="preview">Preview</button>
       </div>
-      <div id="tab-pane-code" class="tab-pane">
+      <div id="drawer-section-code" class="drawer-section">
         <div id="code-output">
           <details class="code-fold" open>
             <summary>Python (tikzfigure) <button class="copy-btn" onclick="event.stopPropagation();copyCode('python')">Copy</button></summary>
@@ -111,13 +101,12 @@
             <summary>TikZ LaTeX <button class="copy-btn" onclick="event.stopPropagation();copyCode('tikz')">Copy</button></summary>
             <pre id="tikz-code">% TikZ code will appear here</pre>
           </details>
-          <details class="code-fold">
-            <summary>Raw TikZ Insert</summary>
-            <textarea id="raw-tikz-input" placeholder="Verbatim TikZ code (added via fig.add_raw)..." rows="3"></textarea>
-          </details>
         </div>
       </div>
-      <div id="tab-pane-pdf" class="tab-pane">
+      <div id="drawer-section-rawtikz" class="drawer-section" style="display:none">
+        <textarea id="raw-tikz-input" placeholder="Verbatim TikZ code (added via fig.add_raw)..." rows="4"></textarea>
+      </div>
+      <div id="drawer-section-preview" class="drawer-section" style="display:none">
         <div id="pdf-pane-inner">
           <button id="compile-btn" disabled>Compile to PDF (latex-on-http)</button>
           <a id="pdf-download" style="display:none;" download="figure.pdf">Download PDF</a>
@@ -128,14 +117,39 @@
           </details>
         </div>
       </div>
-      <div id="tab-pane-layers" class="tab-pane">
-        <div class="panel-body" id="layers-panel"></div>
-      </div>
     </div>
+  </div>
+
+  <div id="right-panel">
+    <details class="inspector-card" id="card-props" open>
+      <summary class="inspector-card-header">Properties</summary>
+      <div class="inspector-card-body">
+        <div id="properties-panel">
+          <p class="hint">Select a node or edge to edit properties.</p>
+        </div>
+      </div>
+    </details>
+    <details class="inspector-card" id="card-layers" open>
+      <summary class="inspector-card-header">Layers</summary>
+      <div class="inspector-card-body">
+        <div id="layers-panel"></div>
+      </div>
+    </details>
   </div>
 </div>
 
 <div id="context-menu"></div>
+
+<div id="compile-dialog-overlay" style="display:none;">
+  <div id="compile-dialog">
+    <div class="dialog-title">Select layers to include in PDF</div>
+    <div id="compile-dialog-layers"></div>
+    <div class="dialog-footer">
+      <button id="dialog-cancel">Cancel</button>
+      <button id="dialog-compile" class="dialog-compile-btn">Compile</button>
+    </div>
+  </div>
+</div>
 
 <div id="status-bar">Ready. Press N to add nodes, E for edges, V to select. Scroll to zoom, middle-click to pan.</div>
 

--- a/astro_docs/public/tikz-editor.html
+++ b/astro_docs/public/tikz-editor.html
@@ -10,27 +10,6 @@
 
 <div id="toolbar">
   <span class="toolbar-brand">TikZ Editor</span>
-  <div class="toolbar-group">
-    <button class="tool-btn active" id="btn-select" title="Select / Move (V)">Select</button>
-    <button class="tool-btn" id="btn-add-node" title="Add Node (N)">Node</button>
-    <button class="tool-btn" id="btn-add-edge" title="Add Edge (E)">Edge</button>
-  </div>
-  <div class="toolbar-sep"></div>
-  <div class="toolbar-group">
-    <button class="tool-btn" id="btn-undo" title="Undo (Ctrl+Z)" disabled>Undo</button>
-    <button class="tool-btn" id="btn-redo" title="Redo (Ctrl+Shift+Z)" disabled>Redo</button>
-  </div>
-  <div class="toolbar-sep"></div>
-  <div class="toolbar-group">
-    <button class="tool-btn" id="btn-duplicate" title="Duplicate (Ctrl+D)">Duplicate</button>
-    <button class="tool-btn" id="btn-delete" title="Delete (Del)">Delete</button>
-    <button class="tool-btn" id="btn-clear" title="Clear all">Clear</button>
-  </div>
-  <div class="toolbar-sep"></div>
-  <div class="toolbar-group">
-    <button class="tool-btn toggle active" id="btn-grid" title="Toggle Grid (G)">Grid</button>
-    <button class="tool-btn toggle active" id="btn-snap" title="Toggle Snap">Snap</button>
-  </div>
   <div class="toolbar-sep"></div>
   <div class="toolbar-group zoom-group">
     <button class="tool-btn small" id="btn-zoom-out" title="Zoom Out">&minus;</button>
@@ -38,12 +17,57 @@
     <button class="tool-btn small" id="btn-zoom-in" title="Zoom In">+</button>
     <button class="tool-btn small" id="btn-zoom-reset" title="Reset View">Fit</button>
   </div>
+  <div class="toolbar-sep"></div>
+  <div class="toolbar-group">
+    <button class="tool-btn toggle active" id="btn-grid" title="Toggle Grid (G)">Grid</button>
+    <button class="tool-btn toggle active" id="btn-snap" title="Toggle Snap">Snap</button>
+  </div>
   <span class="toolbar-spacer"></span>
+  <button class="tool-btn" id="btn-theme" title="Toggle Light/Dark Mode">
+    <svg id="theme-icon-dark" viewBox="0 0 16 16" width="14" height="14"><path d="M8 1a7 7 0 100 14A7 7 0 008 1zm0 12.5a5.5 5.5 0 010-11v11z" fill="currentColor"/></svg>
+    <svg id="theme-icon-light" viewBox="0 0 16 16" width="14" height="14" style="display:none"><circle cx="8" cy="8" r="3.5" fill="currentColor"/><g stroke="currentColor" stroke-width="1.5"><line x1="8" y1="0.5" x2="8" y2="3"/><line x1="8" y1="13" x2="8" y2="15.5"/><line x1="0.5" y1="8" x2="3" y2="8"/><line x1="13" y1="8" x2="15.5" y2="8"/><line x1="2.7" y1="2.7" x2="4.5" y2="4.5"/><line x1="11.5" y1="11.5" x2="13.3" y2="13.3"/><line x1="2.7" y1="13.3" x2="4.5" y2="11.5"/><line x1="11.5" y1="4.5" x2="13.3" y2="2.7"/></g></svg>
+  </button>
   <button class="tool-btn compile-btn" id="btn-compile-toolbar" title="Compile to PDF">PDF</button>
+  <button class="tool-btn" id="btn-export-tex" title="Download .tex file">TEX</button>
   <span id="pyodide-status">Loading Pyodide...</span>
 </div>
 
 <div id="main">
+  <div id="left-toolbar">
+    <div class="lt-group">
+      <button class="lt-btn active" id="btn-select" title="Select / Move (V)">
+        <svg viewBox="0 0 16 16" width="16" height="16"><path d="M3 1l10 7-5 1-2 5z" fill="currentColor"/></svg>
+      </button>
+      <button class="lt-btn" id="btn-add-node" title="Add Node (N)">
+        <svg viewBox="0 0 16 16" width="16" height="16"><path d="M8 2v12M2 8h12" stroke="currentColor" stroke-width="2" fill="none"/></svg>
+      </button>
+      <button class="lt-btn" id="btn-add-edge" title="Draw Path (E)">
+        <svg viewBox="0 0 16 16" width="16" height="16"><path d="M2 14l3-1 8-8-2-2-8 8z" fill="none" stroke="currentColor" stroke-width="1.5"/><circle cx="13" cy="3" r="1.5" fill="currentColor"/></svg>
+      </button>
+    </div>
+    <div class="lt-sep"></div>
+    <div class="lt-group">
+      <button class="lt-btn" id="btn-undo" title="Undo (Ctrl+Z)" disabled>
+        <svg viewBox="0 0 16 16" width="16" height="16"><path d="M5 7l-3-3 3-3" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M2 4h8a4 4 0 010 8H6" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+      </button>
+      <button class="lt-btn" id="btn-redo" title="Redo (Ctrl+Shift+Z)" disabled>
+        <svg viewBox="0 0 16 16" width="16" height="16"><path d="M11 7l3-3-3-3" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M14 4H6a4 4 0 000 8h4" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+      </button>
+    </div>
+    <div class="lt-sep"></div>
+    <div class="lt-group">
+      <button class="lt-btn" id="btn-duplicate" title="Duplicate (Ctrl+D)">
+        <svg viewBox="0 0 16 16" width="16" height="16"><rect x="5" y="5" width="8" height="8" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/><rect x="3" y="3" width="8" height="8" rx="1" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+      </button>
+      <button class="lt-btn" id="btn-delete" title="Delete (Del)">
+        <svg viewBox="0 0 16 16" width="16" height="16"><path d="M4 4h8l-1 10H5zM3 4h10M6 2h4" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+      </button>
+      <button class="lt-btn" id="btn-clear" title="Clear All">
+        <svg viewBox="0 0 16 16" width="16" height="16"><circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M5.5 5.5l5 5M10.5 5.5l-5 5" stroke="currentColor" stroke-width="1.5"/></svg>
+      </button>
+    </div>
+  </div>
+
   <div id="canvas-area" class="mode-select">
     <svg id="svg-canvas">
       <defs>
@@ -63,6 +87,8 @@
         <g id="nodes-layer"></g>
       </g>
     </svg>
+    <div id="template-gallery"></div>
+    <div id="selection-marquee"></div>
   </div>
 
   <div id="resizer"></div>
@@ -85,18 +111,25 @@
             <summary>TikZ LaTeX <button class="copy-btn" onclick="event.stopPropagation();copyCode('tikz')">Copy</button></summary>
             <pre id="tikz-code">% TikZ code will appear here</pre>
           </details>
+          <details class="code-fold">
+            <summary>Raw TikZ Insert</summary>
+            <textarea id="raw-tikz-input" placeholder="Verbatim TikZ code (added via fig.add_raw)..." rows="3"></textarea>
+          </details>
         </div>
       </div>
       <div id="tab-pane-pdf" class="tab-pane">
         <div id="pdf-pane-inner">
           <button id="compile-btn" disabled>Compile to PDF (latex-on-http)</button>
           <a id="pdf-download" style="display:none;" download="figure.pdf">Download PDF</a>
-          <canvas id="pdf-canvas" style="display:none;"></canvas>
+          <iframe id="pdf-viewer" style="display:none;"></iframe>
           <details id="compile-log-details" style="display:none;">
             <summary>Compilation log</summary>
             <pre id="compile-log"></pre>
           </details>
         </div>
+      </div>
+      <div id="tab-pane-layers" class="tab-pane">
+        <div class="panel-body" id="layers-panel"></div>
       </div>
     </div>
   </div>
@@ -107,7 +140,6 @@
 <div id="status-bar">Ready. Press N to add nodes, E for edges, V to select. Scroll to zoom, middle-click to pan.</div>
 
 <script src="https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/build/pdf.min.js"></script>
 <script src="/tikzfigure/tikz-editor.js"></script>
 </body>
 </html>

--- a/astro_docs/public/tikz-editor.js
+++ b/astro_docs/public/tikz-editor.js
@@ -1676,14 +1676,12 @@ async function runCompile(includedLayerIds) {
     });
   }
 
-  const compileBtn = document.getElementById('compile-btn');
   compileBtn.disabled = true;
   compileBtn.textContent = 'Compiling\u2026';
   setStatus('Sending to latex.ytotech.com\u2026');
   showLog('', false);
 
   const pdfDl = document.getElementById('pdf-download');
-  const pdfViewer = document.getElementById('pdf-viewer');
 
   try {
     const resp = await fetch('https://latex.ytotech.com/builds/sync', {

--- a/astro_docs/public/tikz-editor.js
+++ b/astro_docs/public/tikz-editor.js
@@ -1612,6 +1612,126 @@ document.getElementById('drawer-tabs').addEventListener('click', (e) => {
   if (btn) switchDrawerSection(btn.dataset.section);
 });
 
+// ─── Compile Dialog ────────────────────────────────────────────────────────
+
+function openCompileDialog() {
+  if (!state.standaloneLaTeX) {
+    setStatus('No LaTeX code ready — add nodes and wait for Pyodide.');
+    return;
+  }
+  const overlay = document.getElementById('compile-dialog-overlay');
+  const layersContainer = document.getElementById('compile-dialog-layers');
+  const compileDialogBtn = document.getElementById('dialog-compile');
+
+  layersContainer.innerHTML = state.layers.length
+    ? state.layers.map(l => `
+        <label class="dialog-layer-row">
+          <input type="checkbox" data-layer-id="${l.id}" checked>
+          ${l.name}
+        </label>
+      `).join('')
+    : '<label class="dialog-layer-row"><input type="checkbox" data-layer-id="0" checked> Default</label>';
+
+  const updateCompileBtn = () => {
+    const anyChecked = layersContainer.querySelectorAll('input[type="checkbox"]:checked').length > 0;
+    compileDialogBtn.disabled = !anyChecked;
+    compileDialogBtn.title = anyChecked ? '' : 'Select at least one layer.';
+  };
+  layersContainer.addEventListener('change', updateCompileBtn);
+  updateCompileBtn();
+
+  overlay.style.display = 'flex';
+}
+
+function closeCompileDialog() {
+  document.getElementById('compile-dialog-overlay').style.display = 'none';
+}
+
+function executeCompile() {
+  const checkedIds = new Set(
+    Array.from(document.querySelectorAll('#compile-dialog-layers input[type="checkbox"]:checked'))
+      .map(cb => parseInt(cb.dataset.layerId))
+  );
+  closeCompileDialog();
+  runCompile(checkedIds);
+}
+
+async function runCompile(includedLayerIds) {
+  if (!state.standaloneLaTeX) { setStatus('No LaTeX to compile.'); return; }
+
+  const allIncluded = state.layers.every(l => includedLayerIds.has(l.id));
+  let latexToCompile = state.standaloneLaTeX;
+
+  if (!allIncluded) {
+    const excludedNames = state.layers
+      .filter(l => !includedLayerIds.has(l.id))
+      .map(l => l.name);
+    excludedNames.forEach(name => {
+      const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const re = new RegExp(
+        `\\\\begin\\{pgfonlayer\\}\\{${escaped}\\}[\\s\\S]*?\\\\end\\{pgfonlayer\\}`,
+        'g'
+      );
+      latexToCompile = latexToCompile.replace(re, '');
+    });
+  }
+
+  const compileBtn = document.getElementById('compile-btn');
+  compileBtn.disabled = true;
+  compileBtn.textContent = 'Compiling\u2026';
+  setStatus('Sending to latex.ytotech.com\u2026');
+  showLog('', false);
+
+  const pdfDl = document.getElementById('pdf-download');
+  const pdfViewer = document.getElementById('pdf-viewer');
+
+  try {
+    const resp = await fetch('https://latex.ytotech.com/builds/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        compiler: 'pdflatex',
+        resources: [{ main: true, content: latexToCompile }],
+      }),
+    });
+
+    if (resp.status === 201) {
+      const buf = await resp.arrayBuffer();
+      if (state._prevPdfUrl) URL.revokeObjectURL(state._prevPdfUrl);
+      const blob = new Blob([buf], { type: 'application/pdf' });
+      const url = URL.createObjectURL(blob);
+      state._prevPdfUrl = url;
+      pdfViewer.src = url;
+      pdfViewer.style.display = 'block';
+      pdfDl.href = url;
+      pdfDl.style.display = 'inline-block';
+      setStatus('PDF compiled successfully.');
+      showLog('Compilation successful.', false);
+      switchDrawerSection('preview');
+    } else {
+      const json = await resp.json().catch(() => ({}));
+      const log = (json.log_files || {})['__main_document__.log'] || JSON.stringify(json);
+      showLog(log, true);
+      const errLine = log.split('\n').find(l => l.startsWith('!') || /TeX capacity exceeded/i.test(l)) || `HTTP ${resp.status}`;
+      setStatus(`Compilation error: ${errLine.trim()}`);
+      switchDrawerSection('preview');
+    }
+  } catch (err) {
+    setStatus(`Network error: ${err.message}`);
+    showLog(err.message, true);
+  } finally {
+    compileBtn.disabled = false;
+    compileBtn.textContent = 'Compile to PDF (latex-on-http)';
+  }
+}
+
+document.getElementById('dialog-cancel').addEventListener('click', closeCompileDialog);
+document.getElementById('dialog-compile').addEventListener('click', executeCompile);
+document.getElementById('compile-dialog-overlay').addEventListener('click', (e) => {
+  if (e.target === document.getElementById('compile-dialog-overlay')) closeCompileDialog();
+});
+document.getElementById('compile-btn').addEventListener('click', () => openCompileDialog());
+
 // ─── Pyodide ───────────────────────────────────────────────────────────────
 
 async function initPyodide() {
@@ -1658,8 +1778,7 @@ function copyCode(type) {
 window.copyCode = copyCode;
 
 document.getElementById('btn-compile-toolbar').addEventListener('click', () => {
-  if (!compileBtn.disabled) compileBtn.click();
-  else setStatus('No TikZ code ready \u2014 add nodes first.');
+  openCompileDialog();
 });
 
 // ─── Export .tex ──────────────────────────────────────────────────────────
@@ -1700,50 +1819,6 @@ function showLog(text, hasError) {
 }
 
 function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
-
-compileBtn.addEventListener('click', async () => {
-  if (!state.standaloneLaTeX) { setStatus('No LaTeX to compile.'); return; }
-
-  compileBtn.disabled = true;
-  compileBtn.textContent = 'Compiling\u2026';
-  setStatus('Sending to latex.ytotech.com\u2026');
-  showLog('', false);
-
-  const pdfDl = document.getElementById('pdf-download');
-  try {
-    const resp = await fetch('https://latex.ytotech.com/builds/sync', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ compiler: 'pdflatex', resources: [{ main: true, content: state.standaloneLaTeX }] }),
-    });
-
-    if (resp.status === 201) {
-      const buf = await resp.arrayBuffer();
-      if (state._prevPdfUrl) URL.revokeObjectURL(state._prevPdfUrl);
-      const blob = new Blob([buf], { type: 'application/pdf' });
-      const url = URL.createObjectURL(blob);
-      state._prevPdfUrl = url;
-      pdfViewer.src = url;
-      pdfViewer.style.display = 'block';
-      pdfDl.href = url;
-      pdfDl.style.display = 'inline-block';
-      setStatus('PDF compiled successfully.');
-      showLog('Compilation successful.', false);
-    } else {
-      const json = await resp.json().catch(() => ({}));
-      const log = (json.log_files || {})['__main_document__.log'] || JSON.stringify(json);
-      showLog(log, true);
-      const errLine = log.split('\n').find(l => l.startsWith('!') || /TeX capacity exceeded/i.test(l)) || `HTTP ${resp.status}`;
-      setStatus(`Compilation error: ${errLine.trim()}`);
-    }
-  } catch (err) {
-    setStatus(`Network error: ${err.message}`);
-    showLog(err.message, true);
-  } finally {
-    compileBtn.disabled = false;
-    compileBtn.textContent = 'Compile to PDF (latex-on-http)';
-  }
-});
 
 // ─── Theme Toggle ─────────────────────────────────────────────────────────
 

--- a/astro_docs/public/tikz-editor.js
+++ b/astro_docs/public/tikz-editor.js
@@ -1,57 +1,101 @@
-// ─── State ────────────────────────────────────────────────────────────────────
+// ─── State ─────────────────────────────────────────────────────────────────
 
 const state = {
-  nodes: [],   // { id, x, y, label, shape, fill, draw, textColor, minWidth, minHeight, opacity, fillOpacity, drawOpacity, minimumSize, innerSep, outerSep, nodeLineWidth, font, textWidth, align, anchor, rotate, xshift, yshift, scale, roundedCorners, dashPattern, doubleBorder, pattern, shading }
-  edges: [],   // { id, sourceId, targetId, color, lineWidth, arrow, bendLeft, bendRight }
+  nodes: [],
+  edges: [],
   selected: null,        // { type: 'node'|'edge', id }
   mode: 'select',        // 'select' | 'node' | 'edge'
-  edgeSource: null,      // node id while drawing an edge
+  edgeSource: null,
   nextNodeId: 1,
   nextEdgeId: 1,
+  // Zoom & Pan
+  zoom: 1,
+  panX: 0,
+  panY: 0,
+  // Grid & Snap
+  showGrid: true,
+  snapEnabled: true,
+  gridSize: 20,
+  // History
+  undoStack: [],
+  redoStack: [],
+  // Pyodide
   pyodide: null,
   pyodideReady: false,
   standaloneLaTeX: '',
 };
 
-// ─── DOM References ────────────────────────────────────────────────────────────
+// ─── DOM Refs ──────────────────────────────────────────────────────────────
 
-const svgCanvas    = document.getElementById('svg-canvas');
-const nodesLayer   = document.getElementById('nodes-layer');
-const edgesLayer   = document.getElementById('edges-layer');
-const canvasArea   = document.getElementById('canvas-area');
-const statusBar    = document.getElementById('status-bar');
-const propPanel    = document.getElementById('properties-panel');
-const pythonPre    = document.getElementById('python-code');
-const tikzPre      = document.getElementById('tikz-code');
-const compileBtn   = document.getElementById('compile-btn');
-const pdfCanvas    = document.getElementById('pdf-canvas');
+const svgCanvas     = document.getElementById('svg-canvas');
+const worldGroup    = document.getElementById('world');
+const gridBg        = document.getElementById('grid-bg');
+const nodesLayer    = document.getElementById('nodes-layer');
+const edgesLayer    = document.getElementById('edges-layer');
+const canvasArea    = document.getElementById('canvas-area');
+const statusBar     = document.getElementById('status-bar');
+const propPanel     = document.getElementById('properties-panel');
+const pythonPre     = document.getElementById('python-code');
+const tikzPre       = document.getElementById('tikz-code');
+const compileBtn    = document.getElementById('compile-btn');
+const pdfCanvas     = document.getElementById('pdf-canvas');
 const pyodideStatus = document.getElementById('pyodide-status');
-const resizer      = document.getElementById('resizer');
-const rightPanelEl = document.getElementById('right-panel');
+const resizer       = document.getElementById('resizer');
+const rightPanelEl  = document.getElementById('right-panel');
+const contextMenu   = document.getElementById('context-menu');
+const zoomLabel     = document.getElementById('zoom-level');
 
-// ─── Resizer drag ──────────────────────────────────────────────────────────────
+function setStatus(msg) { statusBar.textContent = msg; }
 
-resizer.addEventListener('mousedown', (e) => {
-  e.preventDefault();
-  const startX = e.clientX;
-  const startWidth = rightPanelEl.offsetWidth;
-  const onMove = (ev) => {
-    const newWidth = startWidth + (startX - ev.clientX);
-    rightPanelEl.style.width = `${Math.max(20, newWidth)}px`;
+// ─── History (Undo/Redo) ───────────────────────────────────────────────────
+
+function snapshot() {
+  return {
+    nodes: JSON.parse(JSON.stringify(state.nodes)),
+    edges: JSON.parse(JSON.stringify(state.edges)),
+    nid: state.nextNodeId,
+    eid: state.nextEdgeId,
   };
-  const onUp = () => {
-    document.removeEventListener('mousemove', onMove);
-    document.removeEventListener('mouseup', onUp);
-    document.body.style.cursor = '';
-    document.body.style.userSelect = '';
-  };
-  document.body.style.cursor = 'col-resize';
-  document.body.style.userSelect = 'none';
-  document.addEventListener('mousemove', onMove);
-  document.addEventListener('mouseup', onUp);
-});
+}
 
-// ─── Node defaults ─────────────────────────────────────────────────────────────
+function restore(snap) {
+  state.nodes = snap.nodes;
+  state.edges = snap.edges;
+  state.nextNodeId = snap.nid;
+  state.nextEdgeId = snap.eid;
+}
+
+function saveHistory() {
+  state.undoStack.push(snapshot());
+  if (state.undoStack.length > 60) state.undoStack.shift();
+  state.redoStack = [];
+  updateHistoryButtons();
+}
+
+function undo() {
+  if (!state.undoStack.length) return;
+  state.redoStack.push(snapshot());
+  restore(state.undoStack.pop());
+  clearSelection();
+  updateHistoryButtons();
+  setStatus('Undone.');
+}
+
+function redo() {
+  if (!state.redoStack.length) return;
+  state.undoStack.push(snapshot());
+  restore(state.redoStack.pop());
+  clearSelection();
+  updateHistoryButtons();
+  setStatus('Redone.');
+}
+
+function updateHistoryButtons() {
+  document.getElementById('btn-undo').disabled = !state.undoStack.length;
+  document.getElementById('btn-redo').disabled = !state.redoStack.length;
+}
+
+// ─── Defaults ──────────────────────────────────────────────────────────────
 
 function defaultNode(x, y) {
   return {
@@ -64,7 +108,6 @@ function defaultNode(x, y) {
     textColor: null,
     minWidth: 60,
     minHeight: 30,
-    // Optional extended properties (null = use tikzfigure default)
     opacity: null, fillOpacity: null, drawOpacity: null,
     minimumSize: null,
     innerSep: null, outerSep: null,
@@ -81,26 +124,95 @@ function defaultEdge(sourceId, targetId) {
   return {
     id: `e${state.nextEdgeId++}`,
     sourceId, targetId,
-    color: '#94a3b8',
-    lineWidth: 1.5,
-    arrow: 'stealth',
+    color: '#666666',
+    lineWidth: 1,
+    arrow: 'none',
     bendLeft: 0,
     bendRight: 0,
   };
 }
 
-// ─── SVG Utilities ─────────────────────────────────────────────────────────────
+// ─── Zoom & Pan ────────────────────────────────────────────────────────────
 
-function svgPoint(evt) {
-  const rect = svgCanvas.getBoundingClientRect();
-  return { x: evt.clientX - rect.left, y: evt.clientY - rect.top };
+function updateWorldTransform() {
+  worldGroup.setAttribute('transform', `translate(${state.panX},${state.panY}) scale(${state.zoom})`);
+  zoomLabel.textContent = `${Math.round(state.zoom * 100)}%`;
 }
 
-function snapToGrid(v, grid = 15) {
-  return Math.round(v / grid) * grid;
+function screenToWorld(cx, cy) {
+  const r = svgCanvas.getBoundingClientRect();
+  return {
+    x: (cx - r.left - state.panX) / state.zoom,
+    y: (cy - r.top  - state.panY) / state.zoom,
+  };
 }
 
-// ─── Render ────────────────────────────────────────────────────────────────────
+svgCanvas.addEventListener('wheel', (e) => {
+  e.preventDefault();
+  const factor = e.deltaY > 0 ? 0.92 : 1.08;
+  const r = svgCanvas.getBoundingClientRect();
+  const sx = e.clientX - r.left;
+  const sy = e.clientY - r.top;
+  const wx = (sx - state.panX) / state.zoom;
+  const wy = (sy - state.panY) / state.zoom;
+  state.zoom = Math.max(0.15, Math.min(6, state.zoom * factor));
+  state.panX = sx - wx * state.zoom;
+  state.panY = sy - wy * state.zoom;
+  updateWorldTransform();
+}, { passive: false });
+
+let panDrag = null;
+
+svgCanvas.addEventListener('mousedown', (e) => {
+  if (e.button === 1) {
+    e.preventDefault();
+    panDrag = { sx: e.clientX, sy: e.clientY, px: state.panX, py: state.panY };
+  }
+});
+
+document.addEventListener('mousemove', (e) => {
+  if (!panDrag) return;
+  state.panX = panDrag.px + (e.clientX - panDrag.sx);
+  state.panY = panDrag.py + (e.clientY - panDrag.sy);
+  updateWorldTransform();
+});
+
+document.addEventListener('mouseup', () => { panDrag = null; });
+
+document.getElementById('btn-zoom-in').onclick = () => {
+  state.zoom = Math.min(6, state.zoom * 1.25);
+  updateWorldTransform();
+};
+document.getElementById('btn-zoom-out').onclick = () => {
+  state.zoom = Math.max(0.15, state.zoom / 1.25);
+  updateWorldTransform();
+};
+document.getElementById('btn-zoom-reset').onclick = () => {
+  state.zoom = 1; state.panX = 0; state.panY = 0;
+  updateWorldTransform();
+};
+
+// ─── Grid & Snap ───────────────────────────────────────────────────────────
+
+function toggleGrid() {
+  state.showGrid = !state.showGrid;
+  gridBg.style.display = state.showGrid ? '' : 'none';
+  document.getElementById('btn-grid').classList.toggle('active', state.showGrid);
+}
+
+function toggleSnap() {
+  state.snapEnabled = !state.snapEnabled;
+  document.getElementById('btn-snap').classList.toggle('active', state.snapEnabled);
+}
+
+function snap(v) {
+  return state.snapEnabled ? Math.round(v / state.gridSize) * state.gridSize : Math.round(v);
+}
+
+document.getElementById('btn-grid').onclick = toggleGrid;
+document.getElementById('btn-snap').onclick = toggleSnap;
+
+// ─── Render ────────────────────────────────────────────────────────────────
 
 function renderAll() {
   renderEdges();
@@ -112,41 +224,44 @@ function renderNodes() {
   nodesLayer.innerHTML = '';
   for (const node of state.nodes) {
     const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-    g.setAttribute('class', 'tikz-node' + (state.selected?.type === 'node' && state.selected.id === node.id ? ' selected' : '') + (state.edgeSource === node.id ? ' edge-source' : ''));
+    const isSel = state.selected?.type === 'node' && state.selected.id === node.id;
+    const isSrc = state.edgeSource === node.id;
+    g.setAttribute('class', 'tikz-node' + (isSel ? ' selected' : '') + (isSrc ? ' edge-source' : ''));
     g.setAttribute('data-id', node.id);
     g.setAttribute('transform', `translate(${node.x}, ${node.y})`);
 
     const hw = node.minWidth / 2, hh = node.minHeight / 2;
-
     let shape;
+
     if (node.shape === 'circle') {
       shape = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
       const r = Math.max(hw, hh);
       shape.setAttribute('r', r);
-      shape.setAttribute('cx', 0);
-      shape.setAttribute('cy', 0);
+      shape.setAttribute('cx', 0); shape.setAttribute('cy', 0);
     } else if (node.shape === 'ellipse') {
       shape = document.createElementNS('http://www.w3.org/2000/svg', 'ellipse');
-      shape.setAttribute('rx', hw);
-      shape.setAttribute('ry', hh);
-      shape.setAttribute('cx', 0);
-      shape.setAttribute('cy', 0);
+      shape.setAttribute('rx', hw); shape.setAttribute('ry', hh);
+      shape.setAttribute('cx', 0); shape.setAttribute('cy', 0);
+    } else if (node.shape === 'diamond') {
+      shape = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
+      shape.setAttribute('points', `0,${-hh} ${hw},0 0,${hh} ${-hw},0`);
     } else {
       shape = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-      shape.setAttribute('x', -hw);
-      shape.setAttribute('y', -hh);
-      shape.setAttribute('width', node.minWidth);
-      shape.setAttribute('height', node.minHeight);
-      shape.setAttribute('rx', 4);
+      shape.setAttribute('x', -hw); shape.setAttribute('y', -hh);
+      shape.setAttribute('width', node.minWidth); shape.setAttribute('height', node.minHeight);
+      if (node.roundedCorners) shape.setAttribute('rx', parseInt(node.roundedCorners) || 4);
     }
-    shape.setAttribute('fill', node.fill || '#e2e8f0');
-    shape.setAttribute('stroke', node.draw || '#475569');
+
+    shape.setAttribute('fill', node.fill || 'none');
+    const strokeColor = isSel ? '#818cf8' : isSrc ? '#fbbf24' : (node.draw || '#555');
+    shape.setAttribute('stroke', strokeColor);
+    shape.setAttribute('stroke-width', isSel || isSrc ? 2 : 1);
     g.appendChild(shape);
 
     const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
     text.setAttribute('text-anchor', 'middle');
     text.setAttribute('dominant-baseline', 'central');
-    text.setAttribute('fill', node.textColor || '#1e293b');
+    text.setAttribute('fill', node.textColor || '#c0c4d0');
     text.textContent = node.label;
     g.appendChild(text);
 
@@ -162,73 +277,137 @@ function renderEdges() {
     const tgt = state.nodes.find(n => n.id === edge.targetId);
     if (!src || !tgt) continue;
 
-    const isSelected = state.selected?.type === 'edge' && state.selected.id === edge.id;
+    const isSel = state.selected?.type === 'edge' && state.selected.id === edge.id;
+    const color = isSel ? '#818cf8' : edge.color;
+    const d = edgePath(src, tgt, edge);
 
-    let d;
-    if (edge.bendLeft !== 0 || edge.bendRight !== 0) {
-      const bend = (edge.bendLeft - edge.bendRight) * 0.5;
-      const mx = (src.x + tgt.x) / 2;
-      const my = (src.y + tgt.y) / 2;
-      const dx = tgt.x - src.x, dy = tgt.y - src.y;
-      const len = Math.sqrt(dx * dx + dy * dy) || 1;
-      const cpx = mx + (-dy / len) * bend * 1.5;
-      const cpy = my + (dx / len) * bend * 1.5;
-      d = `M ${src.x} ${src.y} Q ${cpx} ${cpy} ${tgt.x} ${tgt.y}`;
-    } else {
-      d = `M ${src.x} ${src.y} L ${tgt.x} ${tgt.y}`;
-    }
+    // Invisible hit area
+    const hit = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    hit.setAttribute('d', d);
+    hit.setAttribute('stroke', 'transparent');
+    hit.setAttribute('stroke-width', Math.max(12 / state.zoom, edge.lineWidth + 8));
+    hit.setAttribute('fill', 'none');
+    hit.style.cursor = 'pointer';
+    hit.addEventListener('click', (ev) => { ev.stopPropagation(); selectEdge(edge.id); });
+    hit.addEventListener('contextmenu', (ev) => { ev.preventDefault(); ev.stopPropagation(); selectEdge(edge.id); showContextMenu(ev, 'edge', edge); });
+    edgesLayer.appendChild(hit);
 
     const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-    path.setAttribute('class', 'tikz-edge' + (isSelected ? ' selected' : ''));
+    path.setAttribute('class', 'tikz-edge' + (isSel ? ' selected' : ''));
     path.setAttribute('d', d);
-    path.setAttribute('stroke', isSelected ? '#a78bfa' : edge.color);
+    path.setAttribute('stroke', color);
     path.setAttribute('stroke-width', edge.lineWidth);
     if (edge.arrow !== 'none') {
-      path.setAttribute('marker-end', isSelected ? 'url(#arrowhead-selected)' : 'url(#arrowhead)');
+      path.setAttribute('marker-end', isSel ? 'url(#arrowhead-sel)' : 'url(#arrowhead)');
     }
-    path.setAttribute('data-id', edge.id);
-    path.addEventListener('click', () => selectEdge(edge.id));
     edgesLayer.appendChild(path);
   }
 }
 
-// ─── Node drag events ──────────────────────────────────────────────────────────
+function edgePath(src, tgt, edge) {
+  if (edge.bendLeft !== 0 || edge.bendRight !== 0) {
+    const bend = (edge.bendLeft - edge.bendRight) * 0.5;
+    const mx = (src.x + tgt.x) / 2, my = (src.y + tgt.y) / 2;
+    const dx = tgt.x - src.x, dy = tgt.y - src.y;
+    const len = Math.sqrt(dx * dx + dy * dy) || 1;
+    const cx = mx + (-dy / len) * bend * 1.5;
+    const cy = my + (dx / len) * bend * 1.5;
+    return `M ${src.x} ${src.y} Q ${cx} ${cy} ${tgt.x} ${tgt.y}`;
+  }
+  return `M ${src.x} ${src.y} L ${tgt.x} ${tgt.y}`;
+}
+
+// ─── Node Events ───────────────────────────────────────────────────────────
 
 function attachNodeEvents(g, node) {
-  let dragging = false, startX, startY, origX, origY;
+  let dragging = false, didDrag = false, startX, startY, origX, origY;
 
   g.addEventListener('mousedown', (e) => {
-    if (state.mode === 'edge') {
-      handleEdgeClick(node.id);
-      e.stopPropagation();
-      return;
-    }
+    if (e.button !== 0) return;
+    if (state.mode === 'edge') { handleEdgeClick(node.id); e.stopPropagation(); return; }
     if (state.mode !== 'select') return;
     e.stopPropagation();
-    dragging = true;
+    dragging = true; didDrag = false;
     startX = e.clientX; startY = e.clientY;
     origX = node.x; origY = node.y;
     selectNode(node.id);
-    g.style.cursor = 'grabbing';
 
     const onMove = (ev) => {
       if (!dragging) return;
-      node.x = snapToGrid(origX + (ev.clientX - startX));
-      node.y = snapToGrid(origY + (ev.clientY - startY));
+      const dx = (ev.clientX - startX) / state.zoom;
+      const dy = (ev.clientY - startY) / state.zoom;
+      if (Math.abs(dx) > 2 || Math.abs(dy) > 2) didDrag = true;
+      node.x = snap(origX + dx);
+      node.y = snap(origY + dy);
       renderAll();
     };
     const onUp = () => {
+      if (didDrag) saveHistory();
       dragging = false;
-      g.style.cursor = 'grab';
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
     };
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
   });
+
+  g.addEventListener('dblclick', (e) => {
+    e.stopPropagation();
+    startInlineEdit(node);
+  });
+
+  g.addEventListener('contextmenu', (e) => {
+    e.preventDefault(); e.stopPropagation();
+    selectNode(node.id);
+    showContextMenu(e, 'node', node);
+  });
 }
 
-// ─── Selection ─────────────────────────────────────────────────────────────────
+// ─── Inline Label Editing ──────────────────────────────────────────────────
+
+function startInlineEdit(node) {
+  const old = document.getElementById('inline-edit');
+  if (old) old.remove();
+
+  const r = svgCanvas.getBoundingClientRect();
+  const sx = node.x * state.zoom + state.panX + r.left;
+  const sy = node.y * state.zoom + state.panY + r.top;
+
+  const input = document.createElement('input');
+  input.id = 'inline-edit';
+  input.type = 'text';
+  input.value = node.label;
+  Object.assign(input.style, {
+    position: 'fixed',
+    left: `${sx - 50}px`, top: `${sy - 13}px`,
+    width: '100px', height: '26px',
+    textAlign: 'center', fontSize: '12px',
+    background: '#1a1e2e', color: '#e0e4ec',
+    border: '1px solid #818cf8', borderRadius: '4px',
+    outline: 'none', zIndex: '1000', padding: '0 4px',
+    fontFamily: 'inherit',
+  });
+
+  const finish = () => {
+    if (!input.parentNode) return;
+    saveHistory();
+    node.label = input.value || node.label;
+    input.remove();
+    renderAll();
+    showNodeProperties(node);
+  };
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') finish();
+    if (e.key === 'Escape') input.remove();
+    e.stopPropagation();
+  });
+  input.addEventListener('blur', finish);
+  document.body.appendChild(input);
+  input.select();
+}
+
+// ─── Selection ─────────────────────────────────────────────────────────────
 
 function selectNode(id) {
   state.selected = { type: 'node', id };
@@ -246,77 +425,137 @@ function selectEdge(id) {
 
 function clearSelection() {
   state.selected = null;
-  propPanel.innerHTML = '<p style="font-size:0.78rem;color:#64748b;">Select a node or edge to edit its properties.</p>';
+  propPanel.innerHTML = '<p class="hint">Select a node or edge to edit properties.</p>';
   renderAll();
 }
 
-// ─── Edge creation ─────────────────────────────────────────────────────────────
+// ─── Edge Creation ─────────────────────────────────────────────────────────
 
 function handleEdgeClick(nodeId) {
   if (!state.edgeSource) {
     state.edgeSource = nodeId;
-    setStatus('Edge mode: click a target node to connect.');
+    setStatus('Click a target node to connect.');
     renderNodes();
   } else if (state.edgeSource === nodeId) {
     state.edgeSource = null;
-    setStatus('Edge mode: click a source node.');
+    setStatus('Edge cancelled. Click a source node.');
     renderNodes();
   } else {
+    saveHistory();
     const edge = defaultEdge(state.edgeSource, nodeId);
     state.edges.push(edge);
     state.edgeSource = null;
-    setStatus(`Edge added: ${edge.sourceId} → ${edge.targetId}`);
+    setStatus(`Edge: ${edge.sourceId} \u2192 ${edge.targetId}`);
     renderAll();
   }
 }
 
-// ─── Canvas click (add node in node mode) ─────────────────────────────────────
+// ─── Canvas Events ─────────────────────────────────────────────────────────
 
-canvasArea.addEventListener('click', (e) => {
-  if (state.mode !== 'node') return;
-  if (e.target !== svgCanvas && !e.target.closest('#svg-canvas')) return;
-  const pt = svgPoint(e);
-  const node = defaultNode(snapToGrid(pt.x), snapToGrid(pt.y));
-  state.nodes.push(node);
-  selectNode(node.id);
-  setStatus(`Node "${node.label}" added at (${node.x}, ${node.y})`);
-});
-
-svgCanvas.addEventListener('click', (e) => {
-  if (state.mode === 'select' && e.target === svgCanvas) {
-    clearSelection();
+canvasArea.addEventListener('mousedown', (e) => {
+  if (e.button === 0 && state.mode === 'node' && !e.target.closest('.tikz-node')) {
+    const pt = screenToWorld(e.clientX, e.clientY);
+    saveHistory();
+    const node = defaultNode(snap(pt.x), snap(pt.y));
+    state.nodes.push(node);
+    selectNode(node.id);
+    setStatus(`Added "${node.label}".`);
+    return;
+  }
+  if (e.button === 0 && state.mode === 'select') {
+    const t = e.target;
+    if (t === svgCanvas || t === gridBg || t.closest('#world') === worldGroup && !t.closest('.tikz-node') && !t.closest('.tikz-edge')) {
+      clearSelection();
+    }
   }
 });
 
-// ─── Tool buttons ──────────────────────────────────────────────────────────────
+canvasArea.addEventListener('contextmenu', (e) => {
+  e.preventDefault();
+  if (!e.target.closest('.tikz-node')) showContextMenu(e, 'canvas', null);
+});
 
-function setMode(mode) {
-  state.mode = mode;
-  state.edgeSource = null;
-  document.querySelectorAll('.tool-btn').forEach(b => b.classList.remove('active'));
-  canvasArea.className = '';
-  if (mode === 'select') {
-    document.getElementById('btn-select').classList.add('active');
-    canvasArea.classList.add('mode-select');
-    setStatus('Select mode: click nodes or edges to select, drag to move.');
-  } else if (mode === 'node') {
-    document.getElementById('btn-add-node').classList.add('active');
-    canvasArea.classList.add('mode-node');
-    setStatus('Node mode: click on the canvas to add a node.');
-  } else if (mode === 'edge') {
-    document.getElementById('btn-add-edge').classList.add('active');
-    canvasArea.classList.add('mode-edge');
-    setStatus('Edge mode: click a source node, then a target node.');
+// ─── Context Menu ──────────────────────────────────────────────────────────
+
+function showContextMenu(e, type, item) {
+  hideContextMenu();
+  let items = [];
+
+  if (type === 'node') {
+    items = [
+      { label: 'Edit Label', key: 'Dbl-click', action: () => startInlineEdit(item) },
+      { label: 'Duplicate', key: 'Ctrl+D', action: () => duplicateNode(item) },
+      { sep: true },
+      { label: 'Delete', key: 'Del', action: deleteSelected, cls: 'danger' },
+    ];
+  } else if (type === 'edge') {
+    items = [
+      { label: 'Delete', key: 'Del', action: deleteSelected, cls: 'danger' },
+    ];
+  } else {
+    items = [
+      { label: 'Add Node Here', action: () => {
+        const pt = screenToWorld(e.clientX, e.clientY);
+        saveHistory();
+        const n = defaultNode(snap(pt.x), snap(pt.y));
+        state.nodes.push(n);
+        selectNode(n.id);
+      }},
+      { sep: true },
+      { label: (state.showGrid ? '\u2713 ' : '  ') + 'Grid', key: 'G', action: toggleGrid },
+      { label: (state.snapEnabled ? '\u2713 ' : '  ') + 'Snap to Grid', action: toggleSnap },
+      { sep: true },
+      { label: 'Reset View', action: () => { state.zoom = 1; state.panX = 0; state.panY = 0; updateWorldTransform(); } },
+    ];
   }
-  renderNodes();
+
+  contextMenu.innerHTML = items.map(it => {
+    if (it.sep) return '<div class="ctx-sep"></div>';
+    const keyHtml = it.key ? `<span class="ctx-shortcut">${it.key}</span>` : '';
+    return `<button class="ctx-item${it.cls ? ' ' + it.cls : ''}">${it.label}${keyHtml}</button>`;
+  }).join('');
+
+  contextMenu.style.display = 'block';
+  contextMenu.style.left = `${e.clientX}px`;
+  contextMenu.style.top = `${e.clientY}px`;
+
+  // Clamp to viewport
+  requestAnimationFrame(() => {
+    const rect = contextMenu.getBoundingClientRect();
+    if (rect.right > window.innerWidth) contextMenu.style.left = `${window.innerWidth - rect.width - 4}px`;
+    if (rect.bottom > window.innerHeight) contextMenu.style.top = `${window.innerHeight - rect.height - 4}px`;
+  });
+
+  let bi = 0;
+  const btns = contextMenu.querySelectorAll('.ctx-item');
+  items.forEach(it => { if (!it.sep) btns[bi++].addEventListener('click', () => { hideContextMenu(); it.action(); }); });
+
+  setTimeout(() => document.addEventListener('click', hideContextMenu, { once: true }), 0);
 }
 
-document.getElementById('btn-select').onclick = () => setMode('select');
-document.getElementById('btn-add-node').onclick = () => setMode('node');
-document.getElementById('btn-add-edge').onclick = () => setMode('edge');
+function hideContextMenu() { contextMenu.style.display = 'none'; }
 
-document.getElementById('btn-delete').onclick = () => {
+// ─── Duplicate & Delete ────────────────────────────────────────────────────
+
+function duplicateNode(node) {
+  if (!node) {
+    if (!state.selected || state.selected.type !== 'node') return;
+    node = state.nodes.find(n => n.id === state.selected.id);
+    if (!node) return;
+  }
+  saveHistory();
+  const dup = JSON.parse(JSON.stringify(node));
+  dup.id = `n${state.nextNodeId++}`;
+  dup.label = node.label + ' copy';
+  dup.x += 30; dup.y += 30;
+  state.nodes.push(dup);
+  selectNode(dup.id);
+  setStatus(`Duplicated "${node.label}".`);
+}
+
+function deleteSelected() {
   if (!state.selected) return;
+  saveHistory();
   if (state.selected.type === 'node') {
     const id = state.selected.id;
     state.nodes = state.nodes.filter(n => n.id !== id);
@@ -326,52 +565,153 @@ document.getElementById('btn-delete').onclick = () => {
   }
   clearSelection();
   setStatus('Deleted.');
-};
+}
+
+// ─── Mode & Toolbar ────────────────────────────────────────────────────────
+
+function setMode(mode) {
+  state.mode = mode;
+  state.edgeSource = null;
+  document.getElementById('btn-select').classList.toggle('active', mode === 'select');
+  document.getElementById('btn-add-node').classList.toggle('active', mode === 'node');
+  document.getElementById('btn-add-edge').classList.toggle('active', mode === 'edge');
+  canvasArea.className = `mode-${mode}`;
+  const msgs = {
+    select: 'Select mode: click to select, drag to move. Double-click to edit label.',
+    node: 'Node mode: click canvas to place a node.',
+    edge: 'Edge mode: click source, then target node.',
+  };
+  setStatus(msgs[mode]);
+  renderNodes();
+}
+
+document.getElementById('btn-select').onclick = () => setMode('select');
+document.getElementById('btn-add-node').onclick = () => setMode('node');
+document.getElementById('btn-add-edge').onclick = () => setMode('edge');
+document.getElementById('btn-delete').onclick = deleteSelected;
+document.getElementById('btn-duplicate').onclick = () => duplicateNode(null);
+document.getElementById('btn-undo').onclick = undo;
+document.getElementById('btn-redo').onclick = redo;
 
 document.getElementById('btn-clear').onclick = () => {
   if (!confirm('Clear all nodes and edges?')) return;
-  state.nodes = []; state.edges = []; state.nextNodeId = 1; state.nextEdgeId = 1;
+  saveHistory();
+  state.nodes = []; state.edges = [];
+  state.nextNodeId = 1; state.nextEdgeId = 1;
   clearSelection();
-  setStatus('Cleared.');
+  setStatus('Canvas cleared.');
 };
 
-// Keyboard shortcuts
+// ─── Keyboard Shortcuts ────────────────────────────────────────────────────
+
 document.addEventListener('keydown', (e) => {
-  if (e.target.tagName === 'INPUT') return;
+  const tag = e.target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
+  if ((e.ctrlKey || e.metaKey) && !e.shiftKey) {
+    if (e.key === 'z') { e.preventDefault(); undo(); return; }
+    if (e.key === 'd') { e.preventDefault(); duplicateNode(null); return; }
+  }
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'z' || e.key === 'Z')) {
+    e.preventDefault(); redo(); return;
+  }
+
   if (e.key === 'v' || e.key === 'V') setMode('select');
   if (e.key === 'n' || e.key === 'N') setMode('node');
   if (e.key === 'e' || e.key === 'E') setMode('edge');
-  if (e.key === 'Delete' || e.key === 'Backspace') document.getElementById('btn-delete').click();
-  if (e.key === 'Escape') { setMode('select'); clearSelection(); }
+  if (e.key === 'g' || e.key === 'G') toggleGrid();
+  if (e.key === 'Delete' || e.key === 'Backspace') deleteSelected();
+  if (e.key === 'Escape') { setMode('select'); clearSelection(); hideContextMenu(); }
 });
 
-// ─── Status bar ────────────────────────────────────────────────────────────────
+// ─── Resizer ───────────────────────────────────────────────────────────────
 
-function setStatus(msg) { statusBar.textContent = msg; }
+resizer.addEventListener('mousedown', (e) => {
+  e.preventDefault();
+  const startX = e.clientX;
+  const startWidth = rightPanelEl.offsetWidth;
+  const onMove = (ev) => rightPanelEl.style.width = `${Math.max(180, startWidth + (startX - ev.clientX))}px`;
+  const onUp = () => {
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', onUp);
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+  };
+  document.body.style.cursor = 'col-resize';
+  document.body.style.userSelect = 'none';
+  document.addEventListener('mousemove', onMove);
+  document.addEventListener('mouseup', onUp);
+});
 
-// ─── Properties Panel ──────────────────────────────────────────────────────────
+// ─── Properties Panel Helpers ──────────────────────────────────────────────
 
-function propRow(labelText, inputHtml) {
-  return `<div class="prop-row"><label>${labelText}</label>${inputHtml}</div>`;
+function propRow(label, html) {
+  return `<div class="prop-row"><label>${label}</label>${html}</div>`;
 }
+
+function hexColor(c) {
+  if (!c || c === 'none') return '#888888';
+  if (/^#[0-9a-fA-F]{6}$/.test(c)) return c;
+  try {
+    const ctx = document.createElement('canvas').getContext('2d');
+    ctx.fillStyle = c;
+    const s = ctx.fillStyle;
+    if (/^#/.test(s)) return s;
+    const m = s.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+    if (m) return '#' + [m[1],m[2],m[3]].map(x => parseInt(x).toString(16).padStart(2,'0')).join('');
+  } catch {}
+  return '#888888';
+}
+
+function upd() { renderAll(); if (state.pyodideReady) scheduleCodeGen(); }
+
+function bindStr(id, obj, key) {
+  const el = document.getElementById(id);
+  if (el) el.addEventListener('input', () => { obj[key] = el.value || null; upd(); });
+}
+function bindNum(id, obj, key) {
+  const el = document.getElementById(id);
+  if (el) el.addEventListener('input', () => { obj[key] = el.value === '' ? null : Number(el.value); upd(); });
+}
+function bindNumReq(id, obj, key) {
+  const el = document.getElementById(id);
+  if (el) el.addEventListener('input', () => { const v = parseFloat(el.value); if (!isNaN(v)) { obj[key] = v; upd(); } });
+}
+function bindColor(noneId, colorId, obj, key, def = '#000000') {
+  const noneEl = document.getElementById(noneId);
+  const colorEl = document.getElementById(colorId);
+  if (!noneEl || !colorEl) return;
+  noneEl.addEventListener('change', () => {
+    if (noneEl.checked) { obj[key] = null; colorEl.disabled = true; }
+    else { obj[key] = colorEl.value || def; colorEl.disabled = false; }
+    upd();
+  });
+  colorEl.addEventListener('input', () => { obj[key] = colorEl.value; upd(); });
+}
+function bindBool(id, obj, key) {
+  const el = document.getElementById(id);
+  if (el) el.addEventListener('change', () => { obj[key] = el.checked; upd(); });
+}
+
+// ─── Node Properties ───────────────────────────────────────────────────────
 
 function showNodeProperties(node) {
   if (!node) return;
-  const shapeOptions = ['rectangle','circle','ellipse','diamond','star','regular polygon','trapezium','cloud','cylinder','kite'];
-  const anchorOptions = ['center','north','south','east','west','north east','north west','south east','south west'];
-  const alignOptions = ['left','center','right','justify'];
-  const patternOptions = ['horizontal lines','vertical lines','north east lines','north west lines','grid','crosshatch','dots','crosshatch dots','bricks','checkerboard'];
+  const shapes = ['rectangle','circle','ellipse','diamond','star','regular polygon','trapezium','cloud','cylinder','kite'];
+  const anchors = ['center','north','south','east','west','north east','north west','south east','south west'];
+  const aligns = ['left','center','right','justify'];
+  const patterns = ['horizontal lines','vertical lines','north east lines','north west lines','grid','crosshatch','dots','crosshatch dots','bricks','checkerboard'];
 
   propPanel.innerHTML = `
-    <strong style="font-size:0.8rem;color:#a78bfa;display:block;margin-bottom:0.5rem;">Node: ${node.id}</strong>
+    <span class="prop-node-id">Node: ${node.id}</span>
 
     <details class="prop-group" open>
       <summary>Basic</summary>
       <div class="prop-group-body">
         ${propRow('Content', `<input type="text" id="p-label" value="${node.label.replace(/"/g,'&quot;')}">`)}
-        ${propRow('Shape', `<select id="p-shape">${shapeOptions.map(s=>`<option value="${s}"${node.shape===s?' selected':''}>${s}</option>`).join('')}</select>`)}
-        ${propRow('X (px)', `<input type="number" id="p-x" value="${node.x}" step="15">`)}
-        ${propRow('Y (px)', `<input type="number" id="p-y" value="${node.y}" step="15">`)}
+        ${propRow('Shape', `<select id="p-shape">${shapes.map(s=>`<option value="${s}"${node.shape===s?' selected':''}>${s}</option>`).join('')}</select>`)}
+        ${propRow('X', `<input type="number" id="p-x" value="${node.x}" step="${state.gridSize}">`)}
+        ${propRow('Y', `<input type="number" id="p-y" value="${node.y}" step="${state.gridSize}">`)}
       </div>
     </details>
 
@@ -381,14 +721,14 @@ function showNodeProperties(node) {
         ${propRow('Fill', `<label class="color-none-wrap"><input type="checkbox" id="p-fill-none"${!node.fill?' checked':''}>none</label><input type="color" id="p-fill" value="${hexColor(node.fill)}"${!node.fill?' disabled':''}>`)}
         ${propRow('Border', `<label class="color-none-wrap"><input type="checkbox" id="p-draw-none"${!node.draw?' checked':''}>none</label><input type="color" id="p-draw" value="${hexColor(node.draw)}"${!node.draw?' disabled':''}>`)}
         ${propRow('Text', `<label class="color-none-wrap"><input type="checkbox" id="p-text-none"${!node.textColor?' checked':''}>none</label><input type="color" id="p-text" value="${hexColor(node.textColor)}"${!node.textColor?' disabled':''}>`)}
-        ${propRow('Opacity', `<input type="number" id="p-opacity" value="${node.opacity??''}" min="0" max="1" step="0.05" placeholder="0–1">`)}
-        ${propRow('Fill opacity', `<input type="number" id="p-fillopacity" value="${node.fillOpacity??''}" min="0" max="1" step="0.05" placeholder="0–1">`)}
-        ${propRow('Draw opacity', `<input type="number" id="p-drawopacity" value="${node.drawOpacity??''}" min="0" max="1" step="0.05" placeholder="0–1">`)}
+        ${propRow('Opacity', `<input type="number" id="p-opacity" value="${node.opacity??''}" min="0" max="1" step="0.05" placeholder="0\u20131">`)}
+        ${propRow('Fill opacity', `<input type="number" id="p-fillopacity" value="${node.fillOpacity??''}" min="0" max="1" step="0.05" placeholder="0\u20131">`)}
+        ${propRow('Draw opacity', `<input type="number" id="p-drawopacity" value="${node.drawOpacity??''}" min="0" max="1" step="0.05" placeholder="0\u20131">`)}
       </div>
     </details>
 
     <details class="prop-group">
-      <summary>Size &amp; Spacing</summary>
+      <summary>Size & Spacing</summary>
       <div class="prop-group-body">
         ${propRow('Min width', `<input type="number" id="p-mw" value="${node.minWidth}" min="10" step="5">`)}
         ${propRow('Min height', `<input type="number" id="p-mh" value="${node.minHeight}" min="10" step="5">`)}
@@ -404,15 +744,15 @@ function showNodeProperties(node) {
       <div class="prop-group-body">
         ${propRow('Font', `<input type="text" id="p-font" value="${node.font??''}" placeholder="\\\\tiny">`)}
         ${propRow('Text width', `<input type="text" id="p-textwidth" value="${node.textWidth??''}" placeholder="e.g. 3cm">`)}
-        ${propRow('Align', `<select id="p-align"><option value=""${!node.align?' selected':''}>—</option>${alignOptions.map(a=>`<option value="${a}"${node.align===a?' selected':''}>${a}</option>`).join('')}</select>`)}
-        ${propRow('Anchor', `<select id="p-anchor"><option value=""${!node.anchor?' selected':''}>—</option>${anchorOptions.map(a=>`<option value="${a}"${node.anchor===a?' selected':''}>${a}</option>`).join('')}</select>`)}
+        ${propRow('Align', `<select id="p-align"><option value=""${!node.align?' selected':''}>---</option>${aligns.map(a=>`<option value="${a}"${node.align===a?' selected':''}>${a}</option>`).join('')}</select>`)}
+        ${propRow('Anchor', `<select id="p-anchor"><option value=""${!node.anchor?' selected':''}>---</option>${anchors.map(a=>`<option value="${a}"${node.anchor===a?' selected':''}>${a}</option>`).join('')}</select>`)}
       </div>
     </details>
 
     <details class="prop-group">
       <summary>Transform</summary>
       <div class="prop-group-body">
-        ${propRow('Rotate °', `<input type="number" id="p-rotate" value="${node.rotate??''}" step="5" placeholder="degrees">`)}
+        ${propRow('Rotate', `<input type="number" id="p-rotate" value="${node.rotate??''}" step="5" placeholder="degrees">`)}
         ${propRow('X shift', `<input type="text" id="p-xshift" value="${node.xshift??''}" placeholder="e.g. 1cm">`)}
         ${propRow('Y shift', `<input type="text" id="p-yshift" value="${node.yshift??''}" placeholder="e.g. 1cm">`)}
         ${propRow('Scale', `<input type="number" id="p-scale" value="${node.scale??''}" min="0.1" step="0.1" placeholder="1.0">`)}
@@ -431,99 +771,63 @@ function showNodeProperties(node) {
     <details class="prop-group">
       <summary>Pattern / Shading</summary>
       <div class="prop-group-body">
-        ${propRow('Pattern', `<select id="p-pattern"><option value=""${!node.pattern?' selected':''}>— none —</option>${patternOptions.map(p=>`<option value="${p}"${node.pattern===p?' selected':''}>${p}</option>`).join('')}</select>`)}
-        ${propRow('Shading', `<select id="p-shading"><option value=""${!node.shading?' selected':''}>— none —</option>${['axis','radial','ball'].map(s=>`<option value="${s}"${node.shading===s?' selected':''}>${s}</option>`).join('')}</select>`)}
+        ${propRow('Pattern', `<select id="p-pattern"><option value=""${!node.pattern?' selected':''}>none</option>${patterns.map(p=>`<option value="${p}"${node.pattern===p?' selected':''}>${p}</option>`).join('')}</select>`)}
+        ${propRow('Shading', `<select id="p-shading"><option value=""${!node.shading?' selected':''}>none</option>${['axis','radial','ball'].map(s=>`<option value="${s}"${node.shading===s?' selected':''}>${s}</option>`).join('')}</select>`)}
       </div>
     </details>
   `;
 
-  function upd() { renderAll(); if (state.pyodideReady) scheduleCodeGen(); }
-  function bindStr(id, key) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.addEventListener('input', () => { node[key] = el.value || null; upd(); });
-  }
-  function bindNum(id, key) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.addEventListener('input', () => { node[key] = el.value === '' ? null : Number(el.value); upd(); });
-  }
-  function bindNumReq(id, key) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.addEventListener('input', () => { const v = parseFloat(el.value); if (!isNaN(v)) { node[key] = v; upd(); } });
-  }
-  function bindColor(noneId, colorId, key, defaultColor = '#000000') {
-    const noneEl  = document.getElementById(noneId);
-    const colorEl = document.getElementById(colorId);
-    if (!noneEl || !colorEl) return;
-    noneEl.addEventListener('change', () => {
-      if (noneEl.checked) { node[key] = null; colorEl.disabled = true; }
-      else { node[key] = colorEl.value || defaultColor; colorEl.disabled = false; }
-      upd();
-    });
-    colorEl.addEventListener('input', () => { node[key] = colorEl.value; upd(); });
-  }
-  function bindBool(id, key) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.addEventListener('change', () => { node[key] = el.checked; upd(); });
-  }
-
-  // Basic
+  // Bind all
   const labelEl = document.getElementById('p-label');
   if (labelEl) labelEl.addEventListener('input', () => { node.label = labelEl.value; upd(); });
   const shapeEl = document.getElementById('p-shape');
   if (shapeEl) shapeEl.addEventListener('input', () => { node.shape = shapeEl.value; upd(); });
-  bindNumReq('p-x', 'x');
-  bindNumReq('p-y', 'y');
-  // Colors
-  bindColor('p-fill-none', 'p-fill', 'fill', '#e2e8f0');
-  bindColor('p-draw-none', 'p-draw', 'draw', '#475569');
-  bindColor('p-text-none', 'p-text', 'textColor', '#1e293b');
-  bindNum('p-opacity', 'opacity');
-  bindNum('p-fillopacity', 'fillOpacity');
-  bindNum('p-drawopacity', 'drawOpacity');
-  // Size & Spacing
-  bindNumReq('p-mw', 'minWidth');
-  bindNumReq('p-mh', 'minHeight');
-  bindStr('p-minsize', 'minimumSize');
-  bindStr('p-innersep', 'innerSep');
-  bindStr('p-outersep', 'outerSep');
-  bindStr('p-nlw', 'nodeLineWidth');
-  // Text
-  bindStr('p-font', 'font');
-  bindStr('p-textwidth', 'textWidth');
-  bindStr('p-align', 'align');
-  bindStr('p-anchor', 'anchor');
-  // Transform
-  bindNum('p-rotate', 'rotate');
-  bindStr('p-xshift', 'xshift');
-  bindStr('p-yshift', 'yshift');
-  bindNum('p-scale', 'scale');
-  // Border
-  bindStr('p-rounded', 'roundedCorners');
-  bindBool('p-double', 'doubleBorder');
-  bindStr('p-dash', 'dashPattern');
-  // Pattern / Shading
-  bindStr('p-pattern', 'pattern');
-  bindStr('p-shading', 'shading');
+  bindNumReq('p-x', node, 'x');
+  bindNumReq('p-y', node, 'y');
+  bindColor('p-fill-none', 'p-fill', node, 'fill', '#e2e8f0');
+  bindColor('p-draw-none', 'p-draw', node, 'draw', '#475569');
+  bindColor('p-text-none', 'p-text', node, 'textColor', '#1e293b');
+  bindNum('p-opacity', node, 'opacity');
+  bindNum('p-fillopacity', node, 'fillOpacity');
+  bindNum('p-drawopacity', node, 'drawOpacity');
+  bindNumReq('p-mw', node, 'minWidth');
+  bindNumReq('p-mh', node, 'minHeight');
+  bindStr('p-minsize', node, 'minimumSize');
+  bindStr('p-innersep', node, 'innerSep');
+  bindStr('p-outersep', node, 'outerSep');
+  bindStr('p-nlw', node, 'nodeLineWidth');
+  bindStr('p-font', node, 'font');
+  bindStr('p-textwidth', node, 'textWidth');
+  bindStr('p-align', node, 'align');
+  bindStr('p-anchor', node, 'anchor');
+  bindNum('p-rotate', node, 'rotate');
+  bindStr('p-xshift', node, 'xshift');
+  bindStr('p-yshift', node, 'yshift');
+  bindNum('p-scale', node, 'scale');
+  bindStr('p-rounded', node, 'roundedCorners');
+  bindBool('p-double', node, 'doubleBorder');
+  bindStr('p-dash', node, 'dashPattern');
+  bindStr('p-pattern', node, 'pattern');
+  bindStr('p-shading', node, 'shading');
 }
+
+// ─── Edge Properties ───────────────────────────────────────────────────────
 
 function showEdgeProperties(edge) {
   if (!edge) return;
   const src = state.nodes.find(n => n.id === edge.sourceId);
   const tgt = state.nodes.find(n => n.id === edge.targetId);
+
   propPanel.innerHTML = `
-    <strong style="font-size:0.8rem;color:#a78bfa;">Edge: ${edge.id}</strong>
-    <p style="font-size:0.72rem;color:#64748b;margin:0.3rem 0 0.5rem;">${src?.label || edge.sourceId} → ${tgt?.label || edge.targetId}</p>
+    <span class="prop-node-id">Edge: ${edge.id}</span>
+    <p style="font-size:0.68rem;color:#4a4f62;margin:0 0 0.4rem;">${src?.label || edge.sourceId} \u2192 ${tgt?.label || edge.targetId}</p>
     ${propRow('Color', `<input type="color" id="p-ecolor" value="${hexColor(edge.color)}">`)}
     ${propRow('Line width', `<input type="number" id="p-elw" value="${edge.lineWidth}" min="0.5" step="0.5">`)}
     ${propRow('Arrow', `<select id="p-earrow">
-      <option value="stealth" ${edge.arrow==='stealth'?'selected':''}>Stealth →</option>
-      <option value="to" ${edge.arrow==='to'?'selected':''}>To →</option>
-      <option value="latex" ${edge.arrow==='latex'?'selected':''}>LaTeX →</option>
-      <option value="none" ${edge.arrow==='none'?'selected':''}>None</option>
+      <option value="none"${edge.arrow==='none'?' selected':''}>None</option>
+      <option value="stealth"${edge.arrow==='stealth'?' selected':''}>Stealth</option>
+      <option value="to"${edge.arrow==='to'?' selected':''}>To</option>
+      <option value="latex"${edge.arrow==='latex'?' selected':''}>LaTeX</option>
     </select>`)}
     ${propRow('Bend left', `<input type="number" id="p-ebl" value="${edge.bendLeft}" min="-90" max="90" step="5">`)}
     ${propRow('Bend right', `<input type="number" id="p-ebr" value="${edge.bendRight}" min="-90" max="90" step="5">`)}
@@ -531,134 +835,98 @@ function showEdgeProperties(edge) {
 
   const bind = (id, key, parse = v => v) => {
     const el = document.getElementById(id);
-    if (!el) return;
-    el.addEventListener('input', () => {
-      edge[key] = parse(el.value);
-      renderAll();
-      if (state.pyodideReady) scheduleCodeGen();
-    });
+    if (el) el.addEventListener('input', () => { edge[key] = parse(el.value); upd(); });
   };
-
-  bind('p-ecolor',  'color');
-  bind('p-elw',     'lineWidth', Number);
-  bind('p-earrow',  'arrow');
-  bind('p-ebl',     'bendLeft',  Number);
-  bind('p-ebr',     'bendRight', Number);
+  bind('p-ecolor', 'color');
+  bind('p-elw', 'lineWidth', Number);
+  bind('p-earrow', 'arrow');
+  bind('p-ebl', 'bendLeft', Number);
+  bind('p-ebr', 'bendRight', Number);
 }
 
-function hexColor(c) {
-  if (!c || c === 'none') return '#888888';
-  if (/^#[0-9a-fA-F]{6}$/.test(c)) return c;
-  try {
-    const ctx = document.createElement('canvas').getContext('2d');
-    ctx.fillStyle = c;
-    const style = ctx.fillStyle;
-    if (/^#/.test(style)) return style;
-    const m = style.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
-    if (m) return '#' + [m[1],m[2],m[3]].map(x => parseInt(x).toString(16).padStart(2,'0')).join('');
-  } catch {}
-  return '#888888';
-}
-
-// ─── Python Code Generation ────────────────────────────────────────────────────
+// ─── Code Generation ───────────────────────────────────────────────────────
 
 const PX_PER_UNIT = 30;
 
-function svgToTikz(px, py) {
-  const cx = +(px / PX_PER_UNIT).toFixed(2);
-  const cy = +((300 - py) / PX_PER_UNIT).toFixed(2);
-  return { cx, cy };
+function worldToTikz(wx, wy) {
+  return { cx: +(wx / PX_PER_UNIT).toFixed(2), cy: +((600 - wy) / PX_PER_UNIT).toFixed(2) };
 }
 
 function cssColorToLatex(hex) {
   if (!hex || hex === 'none') return null;
   if (/^#[0-9a-fA-F]{6}$/.test(hex)) {
-    const r = parseInt(hex.slice(1,3), 16);
-    const g = parseInt(hex.slice(3,5), 16);
-    const b = parseInt(hex.slice(5,7), 16);
+    const r = parseInt(hex.slice(1,3),16);
+    const g = parseInt(hex.slice(3,5),16);
+    const b = parseInt(hex.slice(5,7),16);
     return `{rgb,255:red,${r};green,${g};blue,${b}}`;
   }
   return hex;
 }
 
 function arrowToTikz(arrow) {
-  const map = { stealth: '-Stealth', to: '->', latex: '-latex', none: '-' };
-  return map[arrow] || '-Stealth';
+  return { stealth: '-Stealth', to: '->', latex: '-latex', none: '-' }[arrow] || '-';
 }
 
 function generatePythonCode() {
-  if (state.nodes.length === 0) return '# Add nodes to the canvas to generate code';
-
+  if (!state.nodes.length) return '# Add nodes to the canvas to generate code';
   const lines = ['from tikzfigure import TikzFigure', '', 'fig = TikzFigure()'];
 
   const colorDefs = [];
   state.nodes.forEach(node => {
-    const fillLatex = cssColorToLatex(node.fill);
-    const drawLatex = cssColorToLatex(node.draw);
-    // Strip outer braces — fig.colorlet wraps in {} itself, so passing {rgb,...} → double braces
-    if (fillLatex && fillLatex.startsWith('{rgb')) {
-      colorDefs.push(`fig.colorlet("${node.id}_fill", "${fillLatex.slice(1, -1)}")`);
-    }
-    if (drawLatex && drawLatex.startsWith('{rgb')) {
-      colorDefs.push(`fig.colorlet("${node.id}_draw", "${drawLatex.slice(1, -1)}")`);
-    }
+    const fl = cssColorToLatex(node.fill);
+    const dl = cssColorToLatex(node.draw);
+    if (fl && fl.startsWith('{rgb')) colorDefs.push(`fig.colorlet("${node.id}_fill", "${fl.slice(1,-1)}")`);
+    if (dl && dl.startsWith('{rgb')) colorDefs.push(`fig.colorlet("${node.id}_draw", "${dl.slice(1,-1)}")`);
   });
-  if (colorDefs.length > 0) {
-    lines.push('');
-    lines.push('# Define colors');
-    colorDefs.forEach(l => lines.push(l));
-  }
+  if (colorDefs.length) { lines.push(''); lines.push('# Define colors'); colorDefs.forEach(l => lines.push(l)); }
 
-  lines.push('');
-  lines.push('# Add nodes');
+  lines.push(''); lines.push('# Add nodes');
   state.nodes.forEach(node => {
-    const { cx, cy } = svgToTikz(node.x, node.y);
+    const { cx, cy } = worldToTikz(node.x, node.y);
     const mw = (node.minWidth / PX_PER_UNIT).toFixed(1) + 'cm';
     const mh = (node.minHeight / PX_PER_UNIT).toFixed(1) + 'cm';
     const fillArg = node.fill && node.fill !== 'none' ? `, fill="${node.id}_fill"` : '';
     const drawArg = node.draw && node.draw !== 'none' ? `, draw="${node.id}_draw"` : '';
     const shapeArg = node.shape !== 'rectangle' ? `, shape="${node.shape}"` : '';
     const textArg = node.textColor ? `, text="${cssColorToLatex(node.textColor)}"` : '';
-    const extraArgs = [];
-    if (node.opacity     != null) extraArgs.push(`opacity=${node.opacity}`);
-    if (node.fillOpacity != null) extraArgs.push(`fill_opacity=${node.fillOpacity}`);
-    if (node.drawOpacity != null) extraArgs.push(`draw_opacity=${node.drawOpacity}`);
-    if (node.minimumSize)  extraArgs.push(`minimum_size="${node.minimumSize}"`);
-    if (node.innerSep)     extraArgs.push(`inner_sep="${node.innerSep}"`);
-    if (node.outerSep)     extraArgs.push(`outer_sep="${node.outerSep}"`);
-    if (node.nodeLineWidth) extraArgs.push(`line_width="${node.nodeLineWidth}"`);
-    if (node.font)         extraArgs.push(`font="${node.font}"`);
-    if (node.textWidth)    extraArgs.push(`text_width="${node.textWidth}"`);
-    if (node.align)        extraArgs.push(`align="${node.align}"`);
-    if (node.anchor)       extraArgs.push(`anchor="${node.anchor}"`);
-    if (node.rotate   != null) extraArgs.push(`rotate=${node.rotate}`);
-    if (node.xshift)       extraArgs.push(`xshift="${node.xshift}"`);
-    if (node.yshift)       extraArgs.push(`yshift="${node.yshift}"`);
-    if (node.scale    != null) extraArgs.push(`scale=${node.scale}`);
-    if (node.roundedCorners) extraArgs.push(`rounded_corners="${node.roundedCorners}"`);
-    if (node.doubleBorder)   extraArgs.push(`double="none"`);
-    if (node.dashPattern)    extraArgs.push(`dash_pattern="${node.dashPattern}"`);
-    if (node.pattern)        extraArgs.push(`pattern="${node.pattern}"`);
-    if (node.shading)        extraArgs.push(`shading="${node.shading}"`);
-    const extraStr = extraArgs.length > 0 ? ', ' + extraArgs.join(', ') : '';
+    const extra = [];
+    if (node.opacity != null) extra.push(`opacity=${node.opacity}`);
+    if (node.fillOpacity != null) extra.push(`fill_opacity=${node.fillOpacity}`);
+    if (node.drawOpacity != null) extra.push(`draw_opacity=${node.drawOpacity}`);
+    if (node.minimumSize) extra.push(`minimum_size="${node.minimumSize}"`);
+    if (node.innerSep) extra.push(`inner_sep="${node.innerSep}"`);
+    if (node.outerSep) extra.push(`outer_sep="${node.outerSep}"`);
+    if (node.nodeLineWidth) extra.push(`line_width="${node.nodeLineWidth}"`);
+    if (node.font) extra.push(`font="${node.font}"`);
+    if (node.textWidth) extra.push(`text_width="${node.textWidth}"`);
+    if (node.align) extra.push(`align="${node.align}"`);
+    if (node.anchor) extra.push(`anchor="${node.anchor}"`);
+    if (node.rotate != null) extra.push(`rotate=${node.rotate}`);
+    if (node.xshift) extra.push(`xshift="${node.xshift}"`);
+    if (node.yshift) extra.push(`yshift="${node.yshift}"`);
+    if (node.scale != null) extra.push(`scale=${node.scale}`);
+    if (node.roundedCorners) extra.push(`rounded_corners="${node.roundedCorners}"`);
+    if (node.doubleBorder) extra.push(`double="none"`);
+    if (node.dashPattern) extra.push(`dash_pattern="${node.dashPattern}"`);
+    if (node.pattern) extra.push(`pattern="${node.pattern}"`);
+    if (node.shading) extra.push(`shading="${node.shading}"`);
+    const extraStr = extra.length ? ', ' + extra.join(', ') : '';
     lines.push(`fig.add_node(x=${cx}, y=${cy}, label="${node.id}", content="${node.label}"${fillArg}${drawArg}${shapeArg}${textArg}, minimum_width="${mw}", minimum_height="${mh}"${extraStr})`);
   });
 
-  if (state.edges.length > 0) {
-    lines.push('');
-    lines.push('# Add edges');
+  if (state.edges.length) {
+    lines.push(''); lines.push('# Add edges');
     state.edges.forEach(edge => {
       const arrowOpt = arrowToTikz(edge.arrow);
       const colorArg = edge.color ? `, color="${cssColorToLatex(edge.color)}"` : '';
       const lwArg = `, line_width="${edge.lineWidth}pt"`;
-      const blArg = edge.bendLeft  !== 0 ? `, bend_left=${edge.bendLeft}` : '';
+      const blArg = edge.bendLeft !== 0 ? `, bend_left=${edge.bendLeft}` : '';
       const brArg = edge.bendRight !== 0 ? `, bend_right=${edge.bendRight}` : '';
       lines.push(`fig.draw(["${edge.sourceId}", "${edge.targetId}"]${colorArg}${lwArg}${blArg}${brArg}, options=["${arrowOpt}"])`);
     });
   }
 
-  lines.push('');
-  lines.push('tikz_code = fig.generate_tikz()');
+  lines.push(''); lines.push('tikz_code = fig.generate_tikz()');
   return lines.join('\n');
 }
 
@@ -672,11 +940,11 @@ function generateCode() {
   const pyCode = generatePythonCode();
   pythonPre.textContent = pyCode;
   if (state.pyodideReady) scheduleCodeGen();
-  else tikzPre.textContent = '% Pyodide loading — TikZ will appear when ready';
+  else tikzPre.textContent = '% Pyodide loading \u2014 TikZ will appear when ready';
 }
 
 async function runCodeGen() {
-  if (!state.pyodideReady || state.nodes.length === 0) return;
+  if (!state.pyodideReady || !state.nodes.length) return;
   const pyCode = generatePythonCode();
   const fullCode = `
 import sys
@@ -689,7 +957,7 @@ standalone_result = fig.generate_standalone()
 `;
   try {
     await state.pyodide.runPythonAsync(fullCode);
-    tikzPre.textContent = state.pyodide.globals.get('tikz_result') || '% (empty output)';
+    tikzPre.textContent = state.pyodide.globals.get('tikz_result') || '% (empty)';
     state.standaloneLaTeX = state.pyodide.globals.get('standalone_result') || '';
     compileBtn.disabled = false;
   } catch (err) {
@@ -699,13 +967,13 @@ standalone_result = fig.generate_standalone()
   }
 }
 
-// ─── Tab System ────────────────────────────────────────────────────────────────
+// ─── Tab System ────────────────────────────────────────────────────────────
 
 const tabState = {
   tabs: [
-    { id: 'props', label: '⚙ Props' },
-    { id: 'code',  label: '＜/＞ Code' },
-    { id: 'pdf',   label: '⚡ PDF' },
+    { id: 'props', label: 'Properties' },
+    { id: 'code',  label: 'Code' },
+    { id: 'pdf',   label: 'PDF' },
   ],
   visible: new Set(['props', 'code', 'pdf']),
   active: 'props',
@@ -727,11 +995,10 @@ function renderTabs() {
 
   tabBar.innerHTML = visible.map(t => `
     <button class="tab-btn${t.id === tabState.active ? ' active' : ''}" data-tab="${t.id}" draggable="true">
-      ${t.label}<span class="tab-hide-btn" data-hide="${t.id}">×</span>
+      ${t.label}<span class="tab-hide-btn" data-hide="${t.id}">\u00d7</span>
     </button>
   `).join('') + (hidden.length ? '<button id="tab-restore-btn" title="Restore hidden tabs">+</button>' : '');
 
-  // Show / hide panes
   tabState.tabs.forEach(t => {
     const pane = document.getElementById(`tab-pane-${t.id}`);
     if (!pane) return;
@@ -740,19 +1007,14 @@ function renderTabs() {
     pane.classList.toggle('active-pane', show);
   });
 
-  // Drag-to-reorder
   tabBar.querySelectorAll('.tab-btn[draggable]').forEach(btn => {
     const id = btn.dataset.tab;
-    btn.addEventListener('dragstart', e => {
-      e.dataTransfer.setData('text/plain', id);
-      btn.classList.add('dragging');
-    });
+    btn.addEventListener('dragstart', e => { e.dataTransfer.setData('text/plain', id); btn.classList.add('dragging'); });
     btn.addEventListener('dragend', () => btn.classList.remove('dragging'));
     btn.addEventListener('dragover', e => { e.preventDefault(); btn.classList.add('drag-over'); });
     btn.addEventListener('dragleave', () => btn.classList.remove('drag-over'));
     btn.addEventListener('drop', e => {
-      e.preventDefault();
-      btn.classList.remove('drag-over');
+      e.preventDefault(); btn.classList.remove('drag-over');
       const from = e.dataTransfer.getData('text/plain'), to = id;
       if (from === to) return;
       const fi = tabState.tabs.findIndex(t => t.id === from);
@@ -764,7 +1026,6 @@ function renderTabs() {
   });
 }
 
-// Single delegated click handler on the persistent tab bar element
 document.getElementById('tab-bar').addEventListener('click', e => {
   const hide = e.target.closest('[data-hide]');
   if (hide) {
@@ -790,13 +1051,7 @@ function showRestoreMenu(anchor) {
   hidden.forEach(tab => {
     const b = document.createElement('button');
     b.textContent = tab.label;
-    b.onclick = ev => {
-      ev.stopPropagation();
-      tabState.visible.add(tab.id);
-      tabState.active = tab.id;
-      renderTabs();
-      menu.remove();
-    };
+    b.onclick = ev => { ev.stopPropagation(); tabState.visible.add(tab.id); tabState.active = tab.id; renderTabs(); menu.remove(); };
     menu.appendChild(b);
   });
   document.getElementById('tab-bar').appendChild(menu);
@@ -805,13 +1060,13 @@ function showRestoreMenu(anchor) {
 
 renderTabs();
 
-// ─── Pyodide Initialization ────────────────────────────────────────────────────
+// ─── Pyodide ───────────────────────────────────────────────────────────────
 
 async function initPyodide() {
-  pyodideStatus.textContent = 'Loading Pyodide…';
+  pyodideStatus.textContent = 'Loading Pyodide\u2026';
   try {
     state.pyodide = await loadPyodide();
-    pyodideStatus.textContent = 'Installing tikzfigure…';
+    pyodideStatus.textContent = 'Installing tikzfigure\u2026';
     await state.pyodide.loadPackage('micropip');
     await state.pyodide.runPythonAsync(`
 import micropip
@@ -819,39 +1074,38 @@ await micropip.install("tikzfigure")
 `);
     state.pyodideReady = true;
     pyodideStatus.style.color = '#6ee7b7';
-    pyodideStatus.textContent = '✓ Pyodide ready';
+    pyodideStatus.textContent = '\u2713 Ready';
     setStatus('Pyodide ready. Add nodes and edges to generate TikZ code.');
-    if (state.nodes.length > 0) runCodeGen();
+    if (state.nodes.length) runCodeGen();
   } catch (err) {
     pyodideStatus.style.color = '#f87171';
-    pyodideStatus.textContent = `✗ Pyodide error: ${err.message}`;
+    pyodideStatus.textContent = `\u2717 ${err.message}`;
   }
 }
 
 initPyodide();
 
-// ─── Copy helpers ──────────────────────────────────────────────────────────────
+// ─── Copy Helpers ──────────────────────────────────────────────────────────
 
 function copyCode(type) {
   const text = type === 'python' ? pythonPre.textContent : tikzPre.textContent;
-  navigator.clipboard.writeText(text).then(() => {
-    setStatus(`Copied ${type === 'python' ? 'Python' : 'TikZ'} code to clipboard.`);
-  }).catch(() => setStatus('Copy failed — use manual selection.'));
+  navigator.clipboard.writeText(text).then(
+    () => setStatus(`Copied ${type === 'python' ? 'Python' : 'TikZ'} code.`),
+    () => setStatus('Copy failed.')
+  );
 }
-
 window.copyCode = copyCode;
 
 document.getElementById('btn-compile-toolbar').addEventListener('click', () => {
   if (!compileBtn.disabled) compileBtn.click();
-  else setStatus('No TikZ code ready yet — add nodes first.');
+  else setStatus('No TikZ code ready \u2014 add nodes first.');
 });
 
-// ─── PDF Compilation via latex-on-http ─────────────────────────────────────────
+// ─── PDF Compilation ───────────────────────────────────────────────────────
 
 const compileLogDetails = document.getElementById('compile-log-details');
 const compileLog        = document.getElementById('compile-log');
 
-// Configure PDF.js worker
 if (typeof pdfjsLib !== 'undefined') {
   pdfjsLib.GlobalWorkerOptions.workerSrc =
     'https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/build/pdf.worker.min.js';
@@ -861,8 +1115,8 @@ function showLog(text, hasError) {
   if (!text) { compileLogDetails.style.display = 'none'; return; }
   const html = text.split('\n').map(line => {
     if (/^!/.test(line) || /error/i.test(line) && !/File:/.test(line))
-      return `<span class="log-error">${escapeHtml(line)}</span>`;
-    return escapeHtml(line);
+      return `<span class="log-error">${esc(line)}</span>`;
+    return esc(line);
   }).join('\n');
   compileLog.innerHTML = html;
   compileLog.className = hasError ? 'has-error' : '';
@@ -870,66 +1124,52 @@ function showLog(text, hasError) {
   compileLogDetails.open = hasError;
 }
 
-function escapeHtml(s) {
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-}
+function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
 
-async function renderPdfToCanvas(arrayBuffer) {
+async function renderPdfToCanvas(buf) {
   if (typeof pdfjsLib === 'undefined') return false;
   try {
-    const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+    const pdf = await pdfjsLib.getDocument({ data: buf }).promise;
     const page = await pdf.getPage(1);
-    const containerWidth = pdfCanvas.parentElement?.clientWidth || 400;
-    const viewport = page.getViewport({ scale: 1 });
-    // Scale so the page fills the container width
-    const scale = (containerWidth - 2) / viewport.width;
-    const scaled = page.getViewport({ scale });
-    pdfCanvas.width  = scaled.width;
-    pdfCanvas.height = scaled.height;
+    const cw = pdfCanvas.parentElement?.clientWidth || 280;
+    const vp = page.getViewport({ scale: 1 });
+    const scale = (cw - 2) / vp.width;
+    const sv = page.getViewport({ scale });
+    pdfCanvas.width = sv.width; pdfCanvas.height = sv.height;
     pdfCanvas.style.display = 'block';
-    const ctx = pdfCanvas.getContext('2d');
-    await page.render({ canvasContext: ctx, viewport: scaled }).promise;
+    await page.render({ canvasContext: pdfCanvas.getContext('2d'), viewport: sv }).promise;
     return true;
   } catch (err) {
-    console.error('PDF.js render error:', err);
+    console.error('PDF.js error:', err);
     return false;
   }
 }
 
 compileBtn.addEventListener('click', async () => {
-  if (!state.standaloneLaTeX) {
-    setStatus('No LaTeX to compile. Add nodes first.');
-    return;
-  }
+  if (!state.standaloneLaTeX) { setStatus('No LaTeX to compile.'); return; }
 
   compileBtn.disabled = true;
-  compileBtn.textContent = 'Compiling…';
-  setStatus('Sending to latex.ytotech.com for compilation…');
+  compileBtn.textContent = 'Compiling\u2026';
+  setStatus('Sending to latex.ytotech.com\u2026');
   showLog('', false);
 
-  const pdfDownload = document.getElementById('pdf-download');
-
+  const pdfDl = document.getElementById('pdf-download');
   try {
     const resp = await fetch('https://latex.ytotech.com/builds/sync', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        compiler: 'pdflatex',
-        resources: [{ main: true, content: state.standaloneLaTeX }],
-      }),
+      body: JSON.stringify({ compiler: 'pdflatex', resources: [{ main: true, content: state.standaloneLaTeX }] }),
     });
 
     if (resp.status === 201) {
-      const arrayBuffer = await resp.arrayBuffer();
-      // Render to canvas via PDF.js (no browser PDF controls)
-      await renderPdfToCanvas(arrayBuffer);
-      // Also make the PDF available as a download
+      const buf = await resp.arrayBuffer();
+      await renderPdfToCanvas(buf);
       if (state._prevPdfUrl) URL.revokeObjectURL(state._prevPdfUrl);
-      const blob = new Blob([arrayBuffer], { type: 'application/pdf' });
+      const blob = new Blob([buf], { type: 'application/pdf' });
       const url = URL.createObjectURL(blob);
       state._prevPdfUrl = url;
-      pdfDownload.href = url;
-      pdfDownload.style.display = 'inline-block';
+      pdfDl.href = url;
+      pdfDl.style.display = 'inline-block';
       setStatus('PDF compiled successfully.');
       showLog('Compilation successful.', false);
     } else {
@@ -944,6 +1184,10 @@ compileBtn.addEventListener('click', async () => {
     showLog(err.message, true);
   } finally {
     compileBtn.disabled = false;
-    compileBtn.textContent = '⚡ Compile to PDF (latex-on-http)';
+    compileBtn.textContent = 'Compile to PDF (latex-on-http)';
   }
 });
+
+// ─── Init ──────────────────────────────────────────────────────────────────
+
+updateWorldTransform();

--- a/astro_docs/public/tikz-editor.js
+++ b/astro_docs/public/tikz-editor.js
@@ -1627,7 +1627,7 @@ function openCompileDialog() {
     ? state.layers.map(l => `
         <label class="dialog-layer-row">
           <input type="checkbox" data-layer-id="${l.id}" checked>
-          ${l.name}
+          ${esc(l.name)}
         </label>
       `).join('')
     : '<label class="dialog-layer-row"><input type="checkbox" data-layer-id="0" checked> Default</label>';
@@ -1637,7 +1637,7 @@ function openCompileDialog() {
     compileDialogBtn.disabled = !anyChecked;
     compileDialogBtn.title = anyChecked ? '' : 'Select at least one layer.';
   };
-  layersContainer.addEventListener('change', updateCompileBtn);
+  layersContainer.onchange = updateCompileBtn;
   updateCompileBtn();
 
   overlay.style.display = 'flex';

--- a/astro_docs/public/tikz-editor.js
+++ b/astro_docs/public/tikz-editor.js
@@ -2,12 +2,16 @@
 
 const state = {
   nodes: [],
-  edges: [],
-  selected: null,        // { type: 'node'|'edge', id }
-  mode: 'select',        // 'select' | 'node' | 'edge'
-  edgeSource: null,
+  paths: [],
+  selected: [],              // array of { type: 'node'|'path', id }
+  mode: 'select',            // 'select' | 'node' | 'edge'
+  pathBuilder: [],            // node IDs being connected
   nextNodeId: 1,
-  nextEdgeId: 1,
+  nextPathId: 1,
+  // Layers
+  layers: [{ id: 0, name: 'Default', visible: true, locked: false }],
+  activeLayer: 0,
+  nextLayerId: 1,
   // Zoom & Pan
   zoom: 1,
   panX: 0,
@@ -23,6 +27,8 @@ const state = {
   pyodide: null,
   pyodideReady: false,
   standaloneLaTeX: '',
+  // Raw TikZ
+  rawTikz: '',
 };
 
 // ─── DOM Refs ──────────────────────────────────────────────────────────────
@@ -38,31 +44,66 @@ const propPanel     = document.getElementById('properties-panel');
 const pythonPre     = document.getElementById('python-code');
 const tikzPre       = document.getElementById('tikz-code');
 const compileBtn    = document.getElementById('compile-btn');
-const pdfCanvas     = document.getElementById('pdf-canvas');
+const pdfViewer     = document.getElementById('pdf-viewer');
 const pyodideStatus = document.getElementById('pyodide-status');
 const resizer       = document.getElementById('resizer');
 const rightPanelEl  = document.getElementById('right-panel');
 const contextMenu   = document.getElementById('context-menu');
 const zoomLabel     = document.getElementById('zoom-level');
+const layersPanel   = document.getElementById('layers-panel');
+const rawTikzInput  = document.getElementById('raw-tikz-input');
+const marqueeEl     = document.getElementById('selection-marquee');
 
 function setStatus(msg) { statusBar.textContent = msg; }
+
+// ─── Selection Helpers ────────────────────────────────────────────────────
+
+function isSelected(type, id) {
+  return state.selected.some(s => s.type === type && s.id === id);
+}
+
+function primarySelection() {
+  return state.selected.length === 1 ? state.selected[0] : null;
+}
+
+function addToSelection(type, id) {
+  if (!isSelected(type, id)) state.selected.push({ type, id });
+}
+
+function removeFromSelection(type, id) {
+  state.selected = state.selected.filter(s => !(s.type === type && s.id === id));
+}
+
+function toggleInSelection(type, id) {
+  if (isSelected(type, id)) removeFromSelection(type, id);
+  else addToSelection(type, id);
+}
 
 // ─── History (Undo/Redo) ───────────────────────────────────────────────────
 
 function snapshot() {
   return {
     nodes: JSON.parse(JSON.stringify(state.nodes)),
-    edges: JSON.parse(JSON.stringify(state.edges)),
+    paths: JSON.parse(JSON.stringify(state.paths)),
+    layers: JSON.parse(JSON.stringify(state.layers)),
+    activeLayer: state.activeLayer,
     nid: state.nextNodeId,
-    eid: state.nextEdgeId,
+    pid: state.nextPathId,
+    lid: state.nextLayerId,
+    rawTikz: state.rawTikz,
   };
 }
 
 function restore(snap) {
   state.nodes = snap.nodes;
-  state.edges = snap.edges;
+  state.paths = snap.paths;
+  state.layers = snap.layers;
+  state.activeLayer = snap.activeLayer;
   state.nextNodeId = snap.nid;
-  state.nextEdgeId = snap.eid;
+  state.nextPathId = snap.pid;
+  state.nextLayerId = snap.lid;
+  state.rawTikz = snap.rawTikz;
+  if (rawTikzInput) rawTikzInput.value = state.rawTikz;
 }
 
 function saveHistory() {
@@ -77,6 +118,7 @@ function undo() {
   state.redoStack.push(snapshot());
   restore(state.undoStack.pop());
   clearSelection();
+  renderLayersPanel();
   updateHistoryButtons();
   setStatus('Undone.');
 }
@@ -86,6 +128,7 @@ function redo() {
   state.undoStack.push(snapshot());
   restore(state.redoStack.pop());
   clearSelection();
+  renderLayersPanel();
   updateHistoryButtons();
   setStatus('Redone.');
 }
@@ -101,13 +144,13 @@ function defaultNode(x, y) {
   return {
     id: `n${state.nextNodeId++}`,
     x, y,
-    label: `Node ${state.nextNodeId - 1}`,
-    shape: 'rectangle',
+    label: '',
+    shape: 'circle',
     fill: null,
     draw: null,
     textColor: null,
-    minWidth: 60,
-    minHeight: 30,
+    minWidth: 40,
+    minHeight: 40,
     opacity: null, fillOpacity: null, drawOpacity: null,
     minimumSize: null,
     innerSep: null, outerSep: null,
@@ -117,19 +160,57 @@ function defaultNode(x, y) {
     rotate: null, xshift: null, yshift: null, scale: null,
     roundedCorners: null, dashPattern: null, doubleBorder: false,
     pattern: null, shading: null,
+    layer: state.activeLayer,
+    comment: null,
   };
 }
 
-function defaultEdge(sourceId, targetId) {
+function defaultPath(nodeIds) {
   return {
-    id: `e${state.nextEdgeId++}`,
-    sourceId, targetId,
+    id: `p${state.nextPathId++}`,
+    nodeIds,
+    cycle: false,
     color: '#666666',
     lineWidth: 1,
+    fill: null,
+    fillOpacity: null,
     arrow: 'none',
-    bendLeft: 0,
-    bendRight: 0,
+    opacity: null,
+    drawOpacity: null,
+    dashPattern: null,
+    dashPhase: null,
+    double: false,
+    doubleDistance: null,
+    roundedCorners: null,
+    bendLeft: null,
+    bendRight: null,
+    decoration: null,
+    lineCap: null,
+    lineJoin: null,
+    layer: state.activeLayer,
+    comment: null,
   };
+}
+
+// ─── Layer Helpers ─────────────────────────────────────────────────────────
+
+function getLayer(id) {
+  return state.layers.find(l => l.id === id);
+}
+
+function isLayerVisible(layerId) {
+  const l = getLayer(layerId);
+  return l ? l.visible : true;
+}
+
+function isLayerLocked(layerId) {
+  const l = getLayer(layerId);
+  return l ? l.locked : false;
+}
+
+function itemCountForLayer(layerId) {
+  return state.nodes.filter(n => n.layer === layerId).length +
+         state.paths.filter(p => p.layer === layerId).length;
 }
 
 // ─── Zoom & Pan ────────────────────────────────────────────────────────────
@@ -215,7 +296,7 @@ document.getElementById('btn-snap').onclick = toggleSnap;
 // ─── Render ────────────────────────────────────────────────────────────────
 
 function renderAll() {
-  renderEdges();
+  renderPaths();
   renderNodes();
   generateCode();
 }
@@ -223,9 +304,11 @@ function renderAll() {
 function renderNodes() {
   nodesLayer.innerHTML = '';
   for (const node of state.nodes) {
+    if (!isLayerVisible(node.layer)) continue;
+
     const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-    const isSel = state.selected?.type === 'node' && state.selected.id === node.id;
-    const isSrc = state.edgeSource === node.id;
+    const isSel = isSelected('node', node.id);
+    const isSrc = state.pathBuilder.includes(node.id);
     g.setAttribute('class', 'tikz-node' + (isSel ? ' selected' : '') + (isSrc ? ' edge-source' : ''));
     g.setAttribute('data-id', node.id);
     g.setAttribute('transform', `translate(${node.x}, ${node.y})`);
@@ -253,92 +336,152 @@ function renderNodes() {
     }
 
     shape.setAttribute('fill', node.fill || 'none');
-    const strokeColor = isSel ? '#818cf8' : isSrc ? '#fbbf24' : (node.draw || '#555');
+    shape.setAttribute('pointer-events', 'all');
+    const strokeColor = isSel ? '#818cf8' : isSrc ? '#fbbf24' : (node.draw || 'var(--node-stroke)');
     shape.setAttribute('stroke', strokeColor);
     shape.setAttribute('stroke-width', isSel || isSrc ? 2 : 1);
+    if (node.opacity != null) shape.setAttribute('opacity', node.opacity);
     g.appendChild(shape);
 
-    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-    text.setAttribute('text-anchor', 'middle');
-    text.setAttribute('dominant-baseline', 'central');
-    text.setAttribute('fill', node.textColor || '#c0c4d0');
-    text.textContent = node.label;
-    g.appendChild(text);
+    if (node.label) {
+      const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      text.setAttribute('text-anchor', 'middle');
+      text.setAttribute('dominant-baseline', 'central');
+      text.setAttribute('fill', node.textColor || 'var(--node-text)');
+      text.textContent = node.label;
+      g.appendChild(text);
+    }
 
     attachNodeEvents(g, node);
     nodesLayer.appendChild(g);
   }
 }
 
-function renderEdges() {
+function renderPaths() {
   edgesLayer.innerHTML = '';
-  for (const edge of state.edges) {
-    const src = state.nodes.find(n => n.id === edge.sourceId);
-    const tgt = state.nodes.find(n => n.id === edge.targetId);
-    if (!src || !tgt) continue;
 
-    const isSel = state.selected?.type === 'edge' && state.selected.id === edge.id;
-    const color = isSel ? '#818cf8' : edge.color;
-    const d = edgePath(src, tgt, edge);
+  // Draw in-progress path builder preview
+  if (state.pathBuilder.length > 0) {
+    const pts = state.pathBuilder.map(id => state.nodes.find(n => n.id === id)).filter(Boolean);
+    if (pts.length >= 1) {
+      let d = `M ${pts[0].x} ${pts[0].y}`;
+      for (let i = 1; i < pts.length; i++) d += ` L ${pts[i].x} ${pts[i].y}`;
+      const preview = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      preview.setAttribute('d', d);
+      preview.setAttribute('stroke', '#818cf8');
+      preview.setAttribute('stroke-width', 1.5);
+      preview.setAttribute('stroke-dasharray', '6 3');
+      preview.setAttribute('fill', 'none');
+      preview.style.pointerEvents = 'none';
+      edgesLayer.appendChild(preview);
+    }
+  }
+
+  for (const p of state.paths) {
+    if (!isLayerVisible(p.layer)) continue;
+
+    const pts = p.nodeIds.map(id => state.nodes.find(n => n.id === id)).filter(Boolean);
+    if (pts.length < 2) continue;
+
+    const isSel = isSelected('path', p.id);
+    const color = isSel ? '#818cf8' : p.color;
+
+    let d = `M ${pts[0].x} ${pts[0].y}`;
+    for (let i = 1; i < pts.length; i++) d += ` L ${pts[i].x} ${pts[i].y}`;
+    if (p.cycle) d += ' Z';
 
     // Invisible hit area
     const hit = document.createElementNS('http://www.w3.org/2000/svg', 'path');
     hit.setAttribute('d', d);
     hit.setAttribute('stroke', 'transparent');
-    hit.setAttribute('stroke-width', Math.max(12 / state.zoom, edge.lineWidth + 8));
-    hit.setAttribute('fill', 'none');
+    hit.setAttribute('stroke-width', Math.max(12 / state.zoom, p.lineWidth + 8));
+    hit.setAttribute('fill', p.cycle ? 'transparent' : 'none');
     hit.style.cursor = 'pointer';
-    hit.addEventListener('click', (ev) => { ev.stopPropagation(); selectEdge(edge.id); });
-    hit.addEventListener('contextmenu', (ev) => { ev.preventDefault(); ev.stopPropagation(); selectEdge(edge.id); showContextMenu(ev, 'edge', edge); });
+    hit.setAttribute('pointer-events', 'all');
+    hit.addEventListener('click', (ev) => { ev.stopPropagation(); selectPath(p.id, ev.shiftKey); });
+    hit.addEventListener('contextmenu', (ev) => { ev.preventDefault(); ev.stopPropagation(); selectPath(p.id); showContextMenu(ev, 'path', p); });
     edgesLayer.appendChild(hit);
 
     const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
     path.setAttribute('class', 'tikz-edge' + (isSel ? ' selected' : ''));
     path.setAttribute('d', d);
     path.setAttribute('stroke', color);
-    path.setAttribute('stroke-width', edge.lineWidth);
-    if (edge.arrow !== 'none') {
+    path.setAttribute('stroke-width', p.double ? p.lineWidth + 2 : p.lineWidth);
+    path.setAttribute('fill', p.fill || 'none');
+    if (p.fill && p.fillOpacity != null) path.setAttribute('fill-opacity', p.fillOpacity);
+    if (p.opacity != null) path.setAttribute('opacity', p.opacity);
+    if (p.drawOpacity != null) path.setAttribute('stroke-opacity', p.drawOpacity);
+    if (p.dashPattern) {
+      const dash = { 'dashed': '8 4', 'dotted': '2 3', 'densely dashed': '4 2', 'loosely dashed': '12 6', 'dash dot': '8 3 2 3' }[p.dashPattern] || p.dashPattern.replace(/on |off /g, '').replace(/pt/g, '');
+      path.setAttribute('stroke-dasharray', dash);
+    }
+    if (p.lineCap) path.setAttribute('stroke-linecap', p.lineCap);
+    if (p.lineJoin) path.setAttribute('stroke-linejoin', p.lineJoin);
+    if (p.roundedCorners) path.setAttribute('stroke-linejoin', 'round');
+    if (p.arrow !== 'none') {
       path.setAttribute('marker-end', isSel ? 'url(#arrowhead-sel)' : 'url(#arrowhead)');
     }
     edgesLayer.appendChild(path);
-  }
-}
 
-function edgePath(src, tgt, edge) {
-  if (edge.bendLeft !== 0 || edge.bendRight !== 0) {
-    const bend = (edge.bendLeft - edge.bendRight) * 0.5;
-    const mx = (src.x + tgt.x) / 2, my = (src.y + tgt.y) / 2;
-    const dx = tgt.x - src.x, dy = tgt.y - src.y;
-    const len = Math.sqrt(dx * dx + dy * dy) || 1;
-    const cx = mx + (-dy / len) * bend * 1.5;
-    const cy = my + (dx / len) * bend * 1.5;
-    return `M ${src.x} ${src.y} Q ${cx} ${cy} ${tgt.x} ${tgt.y}`;
+    if (p.double) {
+      const inner = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      inner.setAttribute('d', d);
+      inner.setAttribute('stroke', p.fill || 'var(--bg-canvas, #0c0e16)');
+      inner.setAttribute('stroke-width', Math.max(1, p.lineWidth - 1));
+      inner.setAttribute('fill', 'none');
+      inner.style.pointerEvents = 'none';
+      edgesLayer.appendChild(inner);
+    }
   }
-  return `M ${src.x} ${src.y} L ${tgt.x} ${tgt.y}`;
 }
 
 // ─── Node Events ───────────────────────────────────────────────────────────
 
 function attachNodeEvents(g, node) {
-  let dragging = false, didDrag = false, startX, startY, origX, origY;
+  let dragging = false, didDrag = false, startX, startY, origPositions;
 
   g.addEventListener('mousedown', (e) => {
     if (e.button !== 0) return;
-    if (state.mode === 'edge') { handleEdgeClick(node.id); e.stopPropagation(); return; }
+    if (state.mode === 'edge') { handlePathClick(node.id); e.stopPropagation(); return; }
     if (state.mode !== 'select') return;
+    if (isLayerLocked(node.layer)) { setStatus(`Layer "${getLayer(node.layer)?.name}" is locked.`); e.stopPropagation(); return; }
     e.stopPropagation();
+
+    // Selection logic
+    if (e.shiftKey) {
+      toggleInSelection('node', node.id);
+    } else if (!isSelected('node', node.id)) {
+      state.selected = [{ type: 'node', id: node.id }];
+    }
+
     dragging = true; didDrag = false;
     startX = e.clientX; startY = e.clientY;
-    origX = node.x; origY = node.y;
-    selectNode(node.id);
+
+    // Store original positions of ALL selected nodes for batch move
+    origPositions = {};
+    state.selected.forEach(s => {
+      if (s.type === 'node') {
+        const n = state.nodes.find(nd => nd.id === s.id);
+        if (n) origPositions[s.id] = { x: n.x, y: n.y };
+      }
+    });
+
+    updatePropertiesPanel();
+    renderAll();
 
     const onMove = (ev) => {
       if (!dragging) return;
       const dx = (ev.clientX - startX) / state.zoom;
       const dy = (ev.clientY - startY) / state.zoom;
       if (Math.abs(dx) > 2 || Math.abs(dy) > 2) didDrag = true;
-      node.x = snap(origX + dx);
-      node.y = snap(origY + dy);
+      // Move all selected nodes
+      for (const [id, orig] of Object.entries(origPositions)) {
+        const n = state.nodes.find(nd => nd.id === id);
+        if (n && !isLayerLocked(n.layer)) {
+          n.x = snap(orig.x + dx);
+          n.y = snap(orig.y + dy);
+        }
+      }
       renderAll();
     };
     const onUp = () => {
@@ -358,7 +501,7 @@ function attachNodeEvents(g, node) {
 
   g.addEventListener('contextmenu', (e) => {
     e.preventDefault(); e.stopPropagation();
-    selectNode(node.id);
+    if (!isSelected('node', node.id)) state.selected = [{ type: 'node', id: node.id }];
     showContextMenu(e, 'node', node);
   });
 }
@@ -382,8 +525,8 @@ function startInlineEdit(node) {
     left: `${sx - 50}px`, top: `${sy - 13}px`,
     width: '100px', height: '26px',
     textAlign: 'center', fontSize: '12px',
-    background: '#1a1e2e', color: '#e0e4ec',
-    border: '1px solid #818cf8', borderRadius: '4px',
+    background: 'var(--bg-input)', color: 'var(--text)',
+    border: '1px solid var(--border-active)', borderRadius: '4px',
     outline: 'none', zIndex: '1000', padding: '0 4px',
     fontFamily: 'inherit',
   });
@@ -394,7 +537,8 @@ function startInlineEdit(node) {
     node.label = input.value || node.label;
     input.remove();
     renderAll();
-    showNodeProperties(node);
+    const prim = primarySelection();
+    if (prim?.type === 'node') showNodeProperties(state.nodes.find(n => n.id === prim.id));
   };
 
   input.addEventListener('keydown', (e) => {
@@ -409,65 +553,212 @@ function startInlineEdit(node) {
 
 // ─── Selection ─────────────────────────────────────────────────────────────
 
-function selectNode(id) {
-  state.selected = { type: 'node', id };
+function selectNode(id, additive = false) {
+  if (additive) {
+    toggleInSelection('node', id);
+  } else {
+    state.selected = [{ type: 'node', id }];
+  }
+  updatePropertiesPanel();
   renderAll();
-  showNodeProperties(state.nodes.find(n => n.id === id));
   switchTab('props');
 }
 
-function selectEdge(id) {
-  state.selected = { type: 'edge', id };
+function selectPath(id, additive = false) {
+  if (additive) {
+    toggleInSelection('path', id);
+  } else {
+    state.selected = [{ type: 'path', id }];
+  }
+  updatePropertiesPanel();
   renderAll();
-  showEdgeProperties(state.edges.find(e => e.id === id));
   switchTab('props');
 }
 
 function clearSelection() {
-  state.selected = null;
+  state.selected = [];
   propPanel.innerHTML = '<p class="hint">Select a node or edge to edit properties.</p>';
   renderAll();
 }
 
-// ─── Edge Creation ─────────────────────────────────────────────────────────
-
-function handleEdgeClick(nodeId) {
-  if (!state.edgeSource) {
-    state.edgeSource = nodeId;
-    setStatus('Click a target node to connect.');
-    renderNodes();
-  } else if (state.edgeSource === nodeId) {
-    state.edgeSource = null;
-    setStatus('Edge cancelled. Click a source node.');
-    renderNodes();
+function updatePropertiesPanel() {
+  const prim = primarySelection();
+  if (prim?.type === 'node') {
+    showNodeProperties(state.nodes.find(n => n.id === prim.id));
+  } else if (prim?.type === 'path') {
+    showPathProperties(state.paths.find(p => p.id === prim.id));
+  } else if (state.selected.length > 1) {
+    showMultiSelectProperties();
   } else {
+    propPanel.innerHTML = '<p class="hint">Select a node or edge to edit properties.</p>';
+  }
+}
+
+function showMultiSelectProperties() {
+  const nodeCount = state.selected.filter(s => s.type === 'node').length;
+  const pathCount = state.selected.filter(s => s.type === 'path').length;
+  const parts = [];
+  if (nodeCount) parts.push(`${nodeCount} node${nodeCount > 1 ? 's' : ''}`);
+  if (pathCount) parts.push(`${pathCount} path${pathCount > 1 ? 's' : ''}`);
+
+  // Collect unique layers in selection
+  const layerIds = new Set();
+  state.selected.forEach(s => {
+    const item = s.type === 'node'
+      ? state.nodes.find(n => n.id === s.id)
+      : state.paths.find(p => p.id === s.id);
+    if (item) layerIds.add(item.layer);
+  });
+
+  const layerOpts = state.layers.map(l => `<option value="${l.id}">${l.name}</option>`).join('');
+
+  propPanel.innerHTML = `
+    <span class="multi-select-info">${parts.join(', ')} selected</span>
+    <p class="hint" style="margin-bottom:0.6rem">Shift+click to add/remove items. Drag to batch-move nodes.</p>
+
+    <details class="prop-group" open>
+      <summary>Batch Actions</summary>
+      <div class="prop-group-body">
+        <button class="batch-btn" id="batch-move-layer">Move to layer: </button>
+        <select id="batch-layer-target" style="font-size:0.68rem;padding:2px 4px;background:var(--bg-input);border:1px solid var(--border-input);color:var(--text);border-radius:3px;">
+          ${layerOpts}
+        </select>
+        <div style="margin-top:0.4rem">
+          <button class="batch-btn danger" id="batch-delete">Delete All Selected</button>
+        </div>
+      </div>
+    </details>
+  `;
+
+  document.getElementById('batch-delete')?.addEventListener('click', deleteSelected);
+  document.getElementById('batch-move-layer')?.addEventListener('click', () => {
+    const targetLayer = parseInt(document.getElementById('batch-layer-target').value);
     saveHistory();
-    const edge = defaultEdge(state.edgeSource, nodeId);
-    state.edges.push(edge);
-    state.edgeSource = null;
-    setStatus(`Edge: ${edge.sourceId} \u2192 ${edge.targetId}`);
+    state.selected.forEach(s => {
+      const item = s.type === 'node'
+        ? state.nodes.find(n => n.id === s.id)
+        : state.paths.find(p => p.id === s.id);
+      if (item) item.layer = targetLayer;
+    });
+    upd();
+    renderLayersPanel();
+    setStatus(`Moved ${state.selected.length} items to layer "${getLayer(targetLayer)?.name}".`);
+  });
+}
+
+// ─── Path Creation ─────────────────────────────────────────────────────────
+
+function handlePathClick(nodeId) {
+  if (state.pathBuilder.length === 0) {
+    state.pathBuilder = [nodeId];
+    setStatus('Path: click more nodes. Enter to finish, click first node to cycle.');
+    renderAll();
+  } else if (nodeId === state.pathBuilder[0] && state.pathBuilder.length >= 2) {
+    finishPath(true);
+  } else if (nodeId === state.pathBuilder[state.pathBuilder.length - 1]) {
+    finishPath(false);
+  } else {
+    state.pathBuilder.push(nodeId);
+    setStatus(`Path: ${state.pathBuilder.length} nodes. Enter to finish, click first node to cycle.`);
     renderAll();
   }
 }
 
-// ─── Canvas Events ─────────────────────────────────────────────────────────
+function finishPath(cycle) {
+  if (state.pathBuilder.length < 2) {
+    state.pathBuilder = [];
+    setStatus('Path cancelled (need at least 2 nodes).');
+    renderAll();
+    return;
+  }
+  saveHistory();
+  const p = defaultPath([...state.pathBuilder]);
+  p.cycle = cycle;
+  state.paths.push(p);
+  state.pathBuilder = [];
+  setStatus(`Path created: ${p.nodeIds.length} nodes${cycle ? ' (cycled)' : ''}.`);
+  selectPath(p.id);
+}
+
+function cancelPath() {
+  if (state.pathBuilder.length > 0) {
+    state.pathBuilder = [];
+    setStatus('Path cancelled.');
+    renderAll();
+  }
+}
+
+// ─── Canvas Events (with Marquee Selection) ───────────────────────────────
+
+let marquee = null;
 
 canvasArea.addEventListener('mousedown', (e) => {
   if (e.button === 0 && state.mode === 'node' && !e.target.closest('.tikz-node')) {
     const pt = screenToWorld(e.clientX, e.clientY);
+    if (isLayerLocked(state.activeLayer)) { setStatus(`Active layer is locked.`); return; }
     saveHistory();
     const node = defaultNode(snap(pt.x), snap(pt.y));
     state.nodes.push(node);
     selectNode(node.id);
-    setStatus(`Added "${node.label}".`);
+    hideTemplateGallery();
+    renderLayersPanel();
+    setStatus(`Added "${node.id}" on layer "${getLayer(state.activeLayer)?.name}".`);
     return;
   }
   if (e.button === 0 && state.mode === 'select') {
     const t = e.target;
-    if (t === svgCanvas || t === gridBg || t.closest('#world') === worldGroup && !t.closest('.tikz-node') && !t.closest('.tikz-edge')) {
-      clearSelection();
+    if (t === svgCanvas || t === gridBg || (t.closest('#world') === worldGroup && !t.closest('.tikz-node') && !t.closest('.tikz-edge'))) {
+      if (!e.shiftKey) clearSelection();
+      // Start marquee selection
+      const r = canvasArea.getBoundingClientRect();
+      marquee = {
+        startX: e.clientX - r.left,
+        startY: e.clientY - r.top,
+        x: e.clientX - r.left,
+        y: e.clientY - r.top,
+      };
     }
   }
+});
+
+canvasArea.addEventListener('mousemove', (e) => {
+  if (!marquee) return;
+  const r = canvasArea.getBoundingClientRect();
+  marquee.x = e.clientX - r.left;
+  marquee.y = e.clientY - r.top;
+  const left = Math.min(marquee.startX, marquee.x);
+  const top = Math.min(marquee.startY, marquee.y);
+  const width = Math.abs(marquee.x - marquee.startX);
+  const height = Math.abs(marquee.y - marquee.startY);
+  if (width > 3 || height > 3) {
+    marqueeEl.style.display = 'block';
+    marqueeEl.style.left = `${left}px`;
+    marqueeEl.style.top = `${top}px`;
+    marqueeEl.style.width = `${width}px`;
+    marqueeEl.style.height = `${height}px`;
+  }
+});
+
+canvasArea.addEventListener('mouseup', (e) => {
+  if (!marquee) return;
+  const width = Math.abs(marquee.x - marquee.startX);
+  const height = Math.abs(marquee.y - marquee.startY);
+  if (width > 5 || height > 5) {
+    // Convert marquee bounds to world coordinates
+    const r = canvasArea.getBoundingClientRect();
+    const wTL = screenToWorld(r.left + Math.min(marquee.startX, marquee.x), r.top + Math.min(marquee.startY, marquee.y));
+    const wBR = screenToWorld(r.left + Math.max(marquee.startX, marquee.x), r.top + Math.max(marquee.startY, marquee.y));
+    // Select nodes within bounds
+    state.nodes.forEach(n => {
+      if (isLayerVisible(n.layer) && n.x >= wTL.x && n.x <= wBR.x && n.y >= wTL.y && n.y <= wBR.y) {
+        addToSelection('node', n.id);
+      }
+    });
+    updatePropertiesPanel();
+    renderAll();
+  }
+  marqueeEl.style.display = 'none';
+  marquee = null;
 });
 
 canvasArea.addEventListener('contextmenu', (e) => {
@@ -482,25 +773,41 @@ function showContextMenu(e, type, item) {
   let items = [];
 
   if (type === 'node') {
+    const count = state.selected.length;
     items = [
       { label: 'Edit Label', key: 'Dbl-click', action: () => startInlineEdit(item) },
-      { label: 'Duplicate', key: 'Ctrl+D', action: () => duplicateNode(item) },
+      { label: 'Duplicate', key: 'Ctrl+D', action: () => duplicateSelected() },
       { sep: true },
-      { label: 'Delete', key: 'Del', action: deleteSelected, cls: 'danger' },
-    ];
-  } else if (type === 'edge') {
+      ...(count > 1 ? [{ label: `Delete ${count} items`, action: deleteSelected, cls: 'danger' }] : []),
+      { label: 'Delete', key: 'Del', action: deleteSelected, cls: count > 1 ? undefined : 'danger' },
+    ].filter((it, i, arr) => !(count > 1 && it.key === 'Del'));
+    if (count > 1) {
+      items = [
+        { label: `${count} items selected`, action: () => {} },
+        { sep: true },
+        { label: 'Duplicate All', key: 'Ctrl+D', action: () => duplicateSelected() },
+        { label: `Delete All (${count})`, action: deleteSelected, cls: 'danger' },
+      ];
+    }
+  } else if (type === 'path') {
     items = [
+      { label: item.cycle ? 'Remove Cycle' : 'Add Cycle', action: () => { item.cycle = !item.cycle; upd(); showPathProperties(item); } },
+      { sep: true },
       { label: 'Delete', key: 'Del', action: deleteSelected, cls: 'danger' },
     ];
   } else {
     items = [
       { label: 'Add Node Here', action: () => {
         const pt = screenToWorld(e.clientX, e.clientY);
+        if (isLayerLocked(state.activeLayer)) { setStatus('Active layer is locked.'); return; }
         saveHistory();
         const n = defaultNode(snap(pt.x), snap(pt.y));
         state.nodes.push(n);
         selectNode(n.id);
+        renderLayersPanel();
       }},
+      { sep: true },
+      { label: `Select All`, key: 'Ctrl+A', action: selectAll },
       { sep: true },
       { label: (state.showGrid ? '\u2713 ' : '  ') + 'Grid', key: 'G', action: toggleGrid },
       { label: (state.snapEnabled ? '\u2713 ' : '  ') + 'Snap to Grid', action: toggleSnap },
@@ -519,7 +826,6 @@ function showContextMenu(e, type, item) {
   contextMenu.style.left = `${e.clientX}px`;
   contextMenu.style.top = `${e.clientY}px`;
 
-  // Clamp to viewport
   requestAnimationFrame(() => {
     const rect = contextMenu.getBoundingClientRect();
     if (rect.right > window.innerWidth) contextMenu.style.left = `${window.innerWidth - rect.width - 4}px`;
@@ -535,51 +841,77 @@ function showContextMenu(e, type, item) {
 
 function hideContextMenu() { contextMenu.style.display = 'none'; }
 
+// ─── Select All ───────────────────────────────────────────────────────────
+
+function selectAll() {
+  state.selected = [];
+  state.nodes.forEach(n => { if (isLayerVisible(n.layer)) state.selected.push({ type: 'node', id: n.id }); });
+  state.paths.forEach(p => { if (isLayerVisible(p.layer)) state.selected.push({ type: 'path', id: p.id }); });
+  updatePropertiesPanel();
+  renderAll();
+  setStatus(`Selected ${state.selected.length} items.`);
+}
+
 // ─── Duplicate & Delete ────────────────────────────────────────────────────
 
-function duplicateNode(node) {
-  if (!node) {
-    if (!state.selected || state.selected.type !== 'node') return;
-    node = state.nodes.find(n => n.id === state.selected.id);
-    if (!node) return;
+function duplicateSelected() {
+  const nodesSel = state.selected.filter(s => s.type === 'node');
+  if (!nodesSel.length) {
+    // If single path selected, nothing to duplicate
+    return;
   }
   saveHistory();
-  const dup = JSON.parse(JSON.stringify(node));
-  dup.id = `n${state.nextNodeId++}`;
-  dup.label = node.label + ' copy';
-  dup.x += 30; dup.y += 30;
-  state.nodes.push(dup);
-  selectNode(dup.id);
-  setStatus(`Duplicated "${node.label}".`);
+  const newSelected = [];
+  nodesSel.forEach(s => {
+    const node = state.nodes.find(n => n.id === s.id);
+    if (!node) return;
+    const dup = JSON.parse(JSON.stringify(node));
+    dup.id = `n${state.nextNodeId++}`;
+    dup.label = node.label ? node.label + ' copy' : '';
+    dup.x += 30; dup.y += 30;
+    state.nodes.push(dup);
+    newSelected.push({ type: 'node', id: dup.id });
+  });
+  state.selected = newSelected;
+  updatePropertiesPanel();
+  renderAll();
+  renderLayersPanel();
+  setStatus(`Duplicated ${nodesSel.length} node(s).`);
 }
 
 function deleteSelected() {
-  if (!state.selected) return;
+  if (!state.selected.length) return;
   saveHistory();
-  if (state.selected.type === 'node') {
-    const id = state.selected.id;
-    state.nodes = state.nodes.filter(n => n.id !== id);
-    state.edges = state.edges.filter(e => e.sourceId !== id && e.targetId !== id);
-  } else {
-    state.edges = state.edges.filter(e => e.id !== state.selected.id);
-  }
+  const nodeIds = new Set(state.selected.filter(s => s.type === 'node').map(s => s.id));
+  const pathIds = new Set(state.selected.filter(s => s.type === 'path').map(s => s.id));
+
+  // Remove selected nodes
+  state.nodes = state.nodes.filter(n => !nodeIds.has(n.id));
+  // Remove selected paths AND paths that reference deleted nodes
+  state.paths = state.paths
+    .filter(p => !pathIds.has(p.id))
+    .map(p => ({ ...p, nodeIds: p.nodeIds.filter(nid => !nodeIds.has(nid)) }))
+    .filter(p => p.nodeIds.length >= 2);
+
   clearSelection();
+  renderLayersPanel();
   setStatus('Deleted.');
 }
 
 // ─── Mode & Toolbar ────────────────────────────────────────────────────────
 
 function setMode(mode) {
+  if (state.mode === 'edge' && mode !== 'edge' && state.pathBuilder.length >= 2) finishPath(false);
   state.mode = mode;
-  state.edgeSource = null;
+  state.pathBuilder = [];
   document.getElementById('btn-select').classList.toggle('active', mode === 'select');
   document.getElementById('btn-add-node').classList.toggle('active', mode === 'node');
   document.getElementById('btn-add-edge').classList.toggle('active', mode === 'edge');
   canvasArea.className = `mode-${mode}`;
   const msgs = {
-    select: 'Select mode: click to select, drag to move. Double-click to edit label.',
+    select: 'Select mode: click to select, shift+click multi-select, drag marquee. Double-click to edit label.',
     node: 'Node mode: click canvas to place a node.',
-    edge: 'Edge mode: click source, then target node.',
+    edge: 'Path mode: click nodes to build a path. Enter to finish, click first node to cycle.',
   };
   setStatus(msgs[mode]);
   renderNodes();
@@ -589,16 +921,20 @@ document.getElementById('btn-select').onclick = () => setMode('select');
 document.getElementById('btn-add-node').onclick = () => setMode('node');
 document.getElementById('btn-add-edge').onclick = () => setMode('edge');
 document.getElementById('btn-delete').onclick = deleteSelected;
-document.getElementById('btn-duplicate').onclick = () => duplicateNode(null);
+document.getElementById('btn-duplicate').onclick = () => duplicateSelected();
 document.getElementById('btn-undo').onclick = undo;
 document.getElementById('btn-redo').onclick = redo;
 
 document.getElementById('btn-clear').onclick = () => {
   if (!confirm('Clear all nodes and edges?')) return;
   saveHistory();
-  state.nodes = []; state.edges = [];
-  state.nextNodeId = 1; state.nextEdgeId = 1;
+  state.nodes = []; state.paths = [];
+  state.nextNodeId = 1; state.nextPathId = 1;
+  state.rawTikz = '';
+  if (rawTikzInput) rawTikzInput.value = '';
   clearSelection();
+  showTemplateGallery();
+  renderLayersPanel();
   setStatus('Canvas cleared.');
 };
 
@@ -610,12 +946,15 @@ document.addEventListener('keydown', (e) => {
 
   if ((e.ctrlKey || e.metaKey) && !e.shiftKey) {
     if (e.key === 'z') { e.preventDefault(); undo(); return; }
-    if (e.key === 'd') { e.preventDefault(); duplicateNode(null); return; }
+    if (e.key === 'd') { e.preventDefault(); duplicateSelected(); return; }
+    if (e.key === 'a') { e.preventDefault(); selectAll(); return; }
   }
   if ((e.ctrlKey || e.metaKey) && e.shiftKey && (e.key === 'z' || e.key === 'Z')) {
     e.preventDefault(); redo(); return;
   }
 
+  if (e.key === 'Enter' && state.mode === 'edge' && state.pathBuilder.length >= 2) { finishPath(false); return; }
+  if (e.key === 'Escape' && state.mode === 'edge' && state.pathBuilder.length > 0) { cancelPath(); return; }
   if (e.key === 'v' || e.key === 'V') setMode('select');
   if (e.key === 'n' || e.key === 'N') setMode('node');
   if (e.key === 'e' || e.key === 'E') setMode('edge');
@@ -693,6 +1032,10 @@ function bindBool(id, obj, key) {
   if (el) el.addEventListener('change', () => { obj[key] = el.checked; upd(); });
 }
 
+function layerSelect(currentLayer) {
+  return `<select id="p-layer">${state.layers.map(l => `<option value="${l.id}"${l.id === currentLayer ? ' selected' : ''}>${l.name}</option>`).join('')}</select>`;
+}
+
 // ─── Node Properties ───────────────────────────────────────────────────────
 
 function showNodeProperties(node) {
@@ -712,6 +1055,8 @@ function showNodeProperties(node) {
         ${propRow('Shape', `<select id="p-shape">${shapes.map(s=>`<option value="${s}"${node.shape===s?' selected':''}>${s}</option>`).join('')}</select>`)}
         ${propRow('X', `<input type="number" id="p-x" value="${node.x}" step="${state.gridSize}">`)}
         ${propRow('Y', `<input type="number" id="p-y" value="${node.y}" step="${state.gridSize}">`)}
+        ${propRow('Layer', layerSelect(node.layer))}
+        ${propRow('Comment', `<input type="text" id="p-comment" value="${(node.comment||'').replace(/"/g,'&quot;')}" placeholder="optional comment">`)}
       </div>
     </details>
 
@@ -809,39 +1154,237 @@ function showNodeProperties(node) {
   bindStr('p-dash', node, 'dashPattern');
   bindStr('p-pattern', node, 'pattern');
   bindStr('p-shading', node, 'shading');
+  bindStr('p-comment', node, 'comment');
+
+  const layerEl = document.getElementById('p-layer');
+  if (layerEl) layerEl.addEventListener('change', () => {
+    node.layer = parseInt(layerEl.value);
+    renderLayersPanel();
+    upd();
+  });
 }
 
-// ─── Edge Properties ───────────────────────────────────────────────────────
+// ─── Path Properties ───────────────────────────────────────────────────────
 
-function showEdgeProperties(edge) {
-  if (!edge) return;
-  const src = state.nodes.find(n => n.id === edge.sourceId);
-  const tgt = state.nodes.find(n => n.id === edge.targetId);
+function showPathProperties(p) {
+  if (!p) return;
+  const nodeNames = p.nodeIds.map(id => {
+    const n = state.nodes.find(nd => nd.id === id);
+    return n?.label || id;
+  }).join(' \u2192 ');
+
+  const dashOpts = ['', 'dashed', 'dotted', 'densely dashed', 'loosely dashed', 'dash dot'];
+  const capOpts = ['', 'butt', 'round', 'rect'];
+  const joinOpts = ['', 'miter', 'round', 'bevel'];
+  const decoOpts = ['', 'snake', 'zigzag', 'coil', 'bumps', 'saw'];
 
   propPanel.innerHTML = `
-    <span class="prop-node-id">Edge: ${edge.id}</span>
-    <p style="font-size:0.68rem;color:#4a4f62;margin:0 0 0.4rem;">${src?.label || edge.sourceId} \u2192 ${tgt?.label || edge.targetId}</p>
-    ${propRow('Color', `<input type="color" id="p-ecolor" value="${hexColor(edge.color)}">`)}
-    ${propRow('Line width', `<input type="number" id="p-elw" value="${edge.lineWidth}" min="0.5" step="0.5">`)}
-    ${propRow('Arrow', `<select id="p-earrow">
-      <option value="none"${edge.arrow==='none'?' selected':''}>None</option>
-      <option value="stealth"${edge.arrow==='stealth'?' selected':''}>Stealth</option>
-      <option value="to"${edge.arrow==='to'?' selected':''}>To</option>
-      <option value="latex"${edge.arrow==='latex'?' selected':''}>LaTeX</option>
-    </select>`)}
-    ${propRow('Bend left', `<input type="number" id="p-ebl" value="${edge.bendLeft}" min="-90" max="90" step="5">`)}
-    ${propRow('Bend right', `<input type="number" id="p-ebr" value="${edge.bendRight}" min="-90" max="90" step="5">`)}
+    <span class="prop-node-id">Path: ${p.id}</span>
+    <p style="font-size:0.68rem;color:var(--text-muted);margin:0 0 0.4rem;word-break:break-all;">${nodeNames}${p.cycle ? ' \u2192 cycle' : ''}</p>
+
+    <details class="prop-group" open>
+      <summary>Path</summary>
+      <div class="prop-group-body">
+        ${propRow('Cycle', `<input type="checkbox" id="p-pcycle"${p.cycle?' checked':''}>`)}
+        ${propRow('Arrow', `<select id="p-parrow">
+          <option value="none"${p.arrow==='none'?' selected':''}>None</option>
+          <option value="stealth"${p.arrow==='stealth'?' selected':''}>-Stealth</option>
+          <option value="to"${p.arrow==='to'?' selected':''}>-></option>
+          <option value="latex"${p.arrow==='latex'?' selected':''}>-latex</option>
+          <option value="stealth-stealth"${p.arrow==='stealth-stealth'?' selected':''}>Stealth-Stealth</option>
+        </select>`)}
+        ${propRow('Layer', layerSelect(p.layer))}
+        ${propRow('Comment', `<input type="text" id="p-comment" value="${(p.comment||'').replace(/"/g,'&quot;')}" placeholder="optional comment">`)}
+      </div>
+    </details>
+
+    <details class="prop-group" open>
+      <summary>Stroke</summary>
+      <div class="prop-group-body">
+        ${propRow('Color', `<input type="color" id="p-pcolor" value="${hexColor(p.color)}">`)}
+        ${propRow('Line width', `<input type="number" id="p-plw" value="${p.lineWidth}" min="0.5" step="0.5">`)}
+        ${propRow('Opacity', `<input type="number" id="p-popacity" value="${p.opacity??''}" min="0" max="1" step="0.05" placeholder="0\u20131">`)}
+        ${propRow('Draw opacity', `<input type="number" id="p-pdrawopacity" value="${p.drawOpacity??''}" min="0" max="1" step="0.05" placeholder="0\u20131">`)}
+      </div>
+    </details>
+
+    <details class="prop-group" open>
+      <summary>Fill</summary>
+      <div class="prop-group-body">
+        ${propRow('Fill', `<label class="color-none-wrap"><input type="checkbox" id="p-pfill-none"${!p.fill?' checked':''}>none</label><input type="color" id="p-pfill" value="${hexColor(p.fill)}"${!p.fill?' disabled':''}>`)}
+        ${propRow('Fill opacity', `<input type="number" id="p-pfillopacity" value="${p.fillOpacity??''}" min="0" max="1" step="0.05" placeholder="0\u20131">`)}
+      </div>
+    </details>
+
+    <details class="prop-group">
+      <summary>Line Style</summary>
+      <div class="prop-group-body">
+        ${propRow('Dash', `<select id="p-pdash">${dashOpts.map(d=>`<option value="${d}"${(p.dashPattern||'')===d?' selected':''}>${d||'solid'}</option>`).join('')}</select>`)}
+        ${propRow('Dash phase', `<input type="text" id="p-pdashphase" value="${p.dashPhase??''}" placeholder="e.g. 2pt">`)}
+        ${propRow('Line cap', `<select id="p-pcap">${capOpts.map(c=>`<option value="${c}"${(p.lineCap||'')===c?' selected':''}>${c||'---'}</option>`).join('')}</select>`)}
+        ${propRow('Line join', `<select id="p-pjoin">${joinOpts.map(j=>`<option value="${j}"${(p.lineJoin||'')===j?' selected':''}>${j||'---'}</option>`).join('')}</select>`)}
+        ${propRow('Rounded', `<input type="text" id="p-prounded" value="${p.roundedCorners??''}" placeholder="e.g. 5pt">`)}
+      </div>
+    </details>
+
+    <details class="prop-group">
+      <summary>Double Line</summary>
+      <div class="prop-group-body">
+        ${propRow('Double', `<input type="checkbox" id="p-pdouble"${p.double?' checked':''}>`)}
+        ${propRow('Distance', `<input type="text" id="p-pdoubledist" value="${p.doubleDistance??''}" placeholder="e.g. 2pt">`)}
+      </div>
+    </details>
+
+    <details class="prop-group">
+      <summary>Bending</summary>
+      <div class="prop-group-body">
+        ${propRow('Bend left', `<input type="number" id="p-pbendleft" value="${p.bendLeft??''}" step="5" placeholder="degrees">`)}
+        ${propRow('Bend right', `<input type="number" id="p-pbendright" value="${p.bendRight??''}" step="5" placeholder="degrees">`)}
+      </div>
+    </details>
+
+    <details class="prop-group">
+      <summary>Decoration</summary>
+      <div class="prop-group-body">
+        ${propRow('Type', `<select id="p-pdeco">${decoOpts.map(d=>`<option value="${d}"${(p.decoration||'')===d?' selected':''}>${d||'none'}</option>`).join('')}</select>`)}
+      </div>
+    </details>
   `;
 
   const bind = (id, key, parse = v => v) => {
     const el = document.getElementById(id);
-    if (el) el.addEventListener('input', () => { edge[key] = parse(el.value); upd(); });
+    if (el) el.addEventListener('input', () => { p[key] = parse(el.value); upd(); });
   };
-  bind('p-ecolor', 'color');
-  bind('p-elw', 'lineWidth', Number);
-  bind('p-earrow', 'arrow');
-  bind('p-ebl', 'bendLeft', Number);
-  bind('p-ebr', 'bendRight', Number);
+  bind('p-pcolor', 'color');
+  bind('p-plw', 'lineWidth', Number);
+  bind('p-parrow', 'arrow');
+  bindNum('p-popacity', p, 'opacity');
+  bindNum('p-pdrawopacity', p, 'drawOpacity');
+  bindStr('p-pdash', p, 'dashPattern');
+  bindStr('p-pdashphase', p, 'dashPhase');
+  bindStr('p-pcap', p, 'lineCap');
+  bindStr('p-pjoin', p, 'lineJoin');
+  bindStr('p-prounded', p, 'roundedCorners');
+  bindBool('p-pdouble', p, 'double');
+  bindStr('p-pdoubledist', p, 'doubleDistance');
+  bindNum('p-pbendleft', p, 'bendLeft');
+  bindNum('p-pbendright', p, 'bendRight');
+  bindStr('p-pdeco', p, 'decoration');
+  bindStr('p-comment', p, 'comment');
+
+  const cycleEl = document.getElementById('p-pcycle');
+  if (cycleEl) cycleEl.addEventListener('change', () => { p.cycle = cycleEl.checked; upd(); showPathProperties(p); });
+
+  bindColor('p-pfill-none', 'p-pfill', p, 'fill', '#4488cc');
+  bindNum('p-pfillopacity', p, 'fillOpacity');
+
+  const layerEl = document.getElementById('p-layer');
+  if (layerEl) layerEl.addEventListener('change', () => {
+    p.layer = parseInt(layerEl.value);
+    renderLayersPanel();
+    upd();
+  });
+}
+
+// ─── Layers Panel ──────────────────────────────────────────────────────────
+
+function renderLayersPanel() {
+  if (!layersPanel) return;
+
+  const rows = state.layers.map(l => {
+    const count = itemCountForLayer(l.id);
+    const isActive = l.id === state.activeLayer;
+    return `
+      <div class="layer-row${isActive ? ' active-layer' : ''}" data-layer-id="${l.id}">
+        <button class="layer-vis-btn${l.visible ? '' : ' hidden-layer'}" data-vis="${l.id}" title="Toggle visibility">${l.visible ? '\u{1F441}' : '\u{1F441}\u200D\u{1F5E8}'}</button>
+        <button class="layer-lock-btn${l.locked ? ' locked-layer' : ''}" data-lock="${l.id}" title="Toggle lock">${l.locked ? '\u{1F512}' : '\u{1F513}'}</button>
+        <span class="layer-name" data-rename="${l.id}">${l.name}</span>
+        <span class="layer-count">${count}</span>
+      </div>
+    `;
+  }).join('');
+
+  layersPanel.innerHTML = `
+    ${rows}
+    <div class="layer-actions">
+      <button class="layer-action-btn" id="layer-add">+ Add</button>
+      <button class="layer-action-btn" id="layer-rename">Rename</button>
+      <button class="layer-action-btn" id="layer-delete">Delete</button>
+    </div>
+  `;
+
+  // Click row to set active layer
+  layersPanel.querySelectorAll('.layer-row').forEach(row => {
+    row.addEventListener('click', (e) => {
+      if (e.target.closest('.layer-vis-btn') || e.target.closest('.layer-lock-btn')) return;
+      state.activeLayer = parseInt(row.dataset.layerId);
+      renderLayersPanel();
+      setStatus(`Active layer: "${getLayer(state.activeLayer)?.name}".`);
+    });
+  });
+
+  // Visibility toggles
+  layersPanel.querySelectorAll('.layer-vis-btn').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const l = getLayer(parseInt(btn.dataset.vis));
+      if (l) { l.visible = !l.visible; renderLayersPanel(); renderAll(); }
+    });
+  });
+
+  // Lock toggles
+  layersPanel.querySelectorAll('.layer-lock-btn').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const l = getLayer(parseInt(btn.dataset.lock));
+      if (l) { l.locked = !l.locked; renderLayersPanel(); }
+    });
+  });
+
+  // Add layer
+  document.getElementById('layer-add')?.addEventListener('click', () => {
+    saveHistory();
+    const newLayer = { id: state.nextLayerId++, name: `Layer ${state.layers.length}`, visible: true, locked: false };
+    state.layers.push(newLayer);
+    state.activeLayer = newLayer.id;
+    renderLayersPanel();
+    setStatus(`Added layer "${newLayer.name}".`);
+  });
+
+  // Rename layer
+  document.getElementById('layer-rename')?.addEventListener('click', () => {
+    const l = getLayer(state.activeLayer);
+    if (!l) return;
+    const name = prompt('Layer name:', l.name);
+    if (name && name.trim()) {
+      saveHistory();
+      l.name = name.trim();
+      renderLayersPanel();
+    }
+  });
+
+  // Delete layer
+  document.getElementById('layer-delete')?.addEventListener('click', () => {
+    if (state.layers.length <= 1) { setStatus('Cannot delete last layer.'); return; }
+    const l = getLayer(state.activeLayer);
+    if (!l) return;
+    const count = itemCountForLayer(l.id);
+    if (count > 0 && !confirm(`Delete layer "${l.name}" and its ${count} items?`)) return;
+    saveHistory();
+    // Remove items on this layer
+    state.nodes = state.nodes.filter(n => n.layer !== l.id);
+    state.paths = state.paths.filter(p => p.layer !== l.id);
+    // Also clean up paths referencing deleted nodes
+    const nodeIds = new Set(state.nodes.map(n => n.id));
+    state.paths = state.paths
+      .map(p => ({ ...p, nodeIds: p.nodeIds.filter(nid => nodeIds.has(nid)) }))
+      .filter(p => p.nodeIds.length >= 2);
+    state.layers = state.layers.filter(ly => ly.id !== l.id);
+    state.activeLayer = state.layers[0].id;
+    clearSelection();
+    renderLayersPanel();
+    setStatus(`Deleted layer "${l.name}".`);
+  });
 }
 
 // ─── Code Generation ───────────────────────────────────────────────────────
@@ -864,13 +1407,91 @@ function cssColorToLatex(hex) {
 }
 
 function arrowToTikz(arrow) {
-  return { stealth: '-Stealth', to: '->', latex: '-latex', none: '-' }[arrow] || '-';
+  return { stealth: '-Stealth', to: '->', latex: '-latex', 'stealth-stealth': 'Stealth-Stealth', none: '-' }[arrow] || '-';
+}
+
+function generateNodeCode(node) {
+  const { cx, cy } = worldToTikz(node.x, node.y);
+  const args = [`x=${cx}`, `y=${cy}`, `label="${node.id}"`];
+  if (node.label) args.push(`content="${node.label}"`);
+  if (node.fill && node.fill !== 'none') args.push(`fill="${node.id}_fill"`);
+  if (node.draw && node.draw !== 'none') args.push(`draw="${node.id}_draw"`);
+  if (node.shape !== 'rectangle') args.push(`shape="${node.shape}"`);
+  if (node.textColor) args.push(`text="${cssColorToLatex(node.textColor)}"`);
+  if (node.minWidth !== 40) args.push(`minimum_width="${(node.minWidth / PX_PER_UNIT).toFixed(1)}cm"`);
+  if (node.minHeight !== 40) args.push(`minimum_height="${(node.minHeight / PX_PER_UNIT).toFixed(1)}cm"`);
+  if (node.opacity != null) args.push(`opacity=${node.opacity}`);
+  if (node.fillOpacity != null) args.push(`fill_opacity=${node.fillOpacity}`);
+  if (node.drawOpacity != null) args.push(`draw_opacity=${node.drawOpacity}`);
+  if (node.minimumSize) args.push(`minimum_size="${node.minimumSize}"`);
+  if (node.innerSep) args.push(`inner_sep="${node.innerSep}"`);
+  if (node.outerSep) args.push(`outer_sep="${node.outerSep}"`);
+  if (node.nodeLineWidth) args.push(`line_width="${node.nodeLineWidth}"`);
+  if (node.font) args.push(`font="${node.font}"`);
+  if (node.textWidth) args.push(`text_width="${node.textWidth}"`);
+  if (node.align) args.push(`align="${node.align}"`);
+  if (node.anchor) args.push(`anchor="${node.anchor}"`);
+  if (node.rotate != null) args.push(`rotate=${node.rotate}`);
+  if (node.xshift) args.push(`xshift="${node.xshift}"`);
+  if (node.yshift) args.push(`yshift="${node.yshift}"`);
+  if (node.scale != null) args.push(`scale=${node.scale}`);
+  if (node.roundedCorners) args.push(`rounded_corners="${node.roundedCorners}"`);
+  if (node.doubleBorder) args.push(`double="none"`);
+  if (node.dashPattern) args.push(`dash_pattern="${node.dashPattern}"`);
+  if (node.pattern) args.push(`pattern="${node.pattern}"`);
+  if (node.shading) args.push(`shading="${node.shading}"`);
+  if (node.comment) args.push(`comment="${node.comment}"`);
+  return `fig.add_node(${args.join(', ')})`;
+}
+
+function generatePathCode(p) {
+  const nodeList = `[${p.nodeIds.map(id => `"${id}"`).join(', ')}]`;
+  const args = [nodeList];
+
+  // options (flag-style)
+  const opts = [];
+  if (p.arrow !== 'none') opts.push(`"${arrowToTikz(p.arrow)}"`);
+  if (p.dashPattern) opts.push(`"${p.dashPattern}"`);
+  if (p.decoration) opts.push(`"decorate"`, `"decoration=${p.decoration}"`);
+  if (opts.length) args.push(`options=[${opts.join(', ')}]`);
+
+  if (p.cycle) args.push(`cycle=True`);
+
+  if (p.color && p.color !== '#666666') {
+    const cl = cssColorToLatex(p.color);
+    if (cl && cl.startsWith('{rgb')) args.push(`color="${p.id}_color"`);
+    else if (cl) args.push(`color="${cl}"`);
+  }
+
+  const hasFill = p.fill && p.fill !== 'none';
+  if (hasFill) {
+    const fl = cssColorToLatex(p.fill);
+    if (fl && fl.startsWith('{rgb')) args.push(`fill="${p.id}_fill"`);
+    else if (fl) args.push(`fill="${fl}"`);
+  }
+
+  if (p.opacity != null) args.push(`opacity=${p.opacity}`);
+  if (p.drawOpacity != null) args.push(`draw_opacity=${p.drawOpacity}`);
+  if (p.fillOpacity != null && hasFill) args.push(`fill_opacity=${p.fillOpacity}`);
+  if (p.lineWidth !== 1) args.push(`line_width=${p.lineWidth}`);
+  if (p.dashPhase) args.push(`dash_phase="${p.dashPhase}"`);
+  if (p.lineCap) args.push(`line_cap="${p.lineCap}"`);
+  if (p.lineJoin) args.push(`line_join="${p.lineJoin}"`);
+  if (p.roundedCorners) args.push(`rounded_corners="${p.roundedCorners}"`);
+  if (p.double) args.push(`double="white"`);
+  if (p.doubleDistance) args.push(`double_distance="${p.doubleDistance}"`);
+  if (p.bendLeft != null) args.push(`bend_left=${p.bendLeft}`);
+  if (p.bendRight != null) args.push(`bend_right=${p.bendRight}`);
+  if (p.comment) args.push(`comment="${p.comment}"`);
+
+  return `fig.draw(${args.join(', ')})`;
 }
 
 function generatePythonCode() {
-  if (!state.nodes.length) return '# Add nodes to the canvas to generate code';
+  if (!state.nodes.length && !state.rawTikz) return '# Add nodes to the canvas to generate code';
   const lines = ['from tikzfigure import TikzFigure', '', 'fig = TikzFigure()'];
 
+  // Color definitions
   const colorDefs = [];
   state.nodes.forEach(node => {
     const fl = cssColorToLatex(node.fill);
@@ -878,52 +1499,68 @@ function generatePythonCode() {
     if (fl && fl.startsWith('{rgb')) colorDefs.push(`fig.colorlet("${node.id}_fill", "${fl.slice(1,-1)}")`);
     if (dl && dl.startsWith('{rgb')) colorDefs.push(`fig.colorlet("${node.id}_draw", "${dl.slice(1,-1)}")`);
   });
+  state.paths.forEach(p => {
+    const fl = cssColorToLatex(p.fill);
+    if (fl && fl.startsWith('{rgb')) colorDefs.push(`fig.colorlet("${p.id}_fill", "${fl.slice(1,-1)}")`);
+    const cl = cssColorToLatex(p.color);
+    if (cl && cl.startsWith('{rgb') && p.color !== '#666666') colorDefs.push(`fig.colorlet("${p.id}_color", "${cl.slice(1,-1)}")`);
+  });
   if (colorDefs.length) { lines.push(''); lines.push('# Define colors'); colorDefs.forEach(l => lines.push(l)); }
 
-  lines.push(''); lines.push('# Add nodes');
-  state.nodes.forEach(node => {
-    const { cx, cy } = worldToTikz(node.x, node.y);
-    const mw = (node.minWidth / PX_PER_UNIT).toFixed(1) + 'cm';
-    const mh = (node.minHeight / PX_PER_UNIT).toFixed(1) + 'cm';
-    const fillArg = node.fill && node.fill !== 'none' ? `, fill="${node.id}_fill"` : '';
-    const drawArg = node.draw && node.draw !== 'none' ? `, draw="${node.id}_draw"` : '';
-    const shapeArg = node.shape !== 'rectangle' ? `, shape="${node.shape}"` : '';
-    const textArg = node.textColor ? `, text="${cssColorToLatex(node.textColor)}"` : '';
-    const extra = [];
-    if (node.opacity != null) extra.push(`opacity=${node.opacity}`);
-    if (node.fillOpacity != null) extra.push(`fill_opacity=${node.fillOpacity}`);
-    if (node.drawOpacity != null) extra.push(`draw_opacity=${node.drawOpacity}`);
-    if (node.minimumSize) extra.push(`minimum_size="${node.minimumSize}"`);
-    if (node.innerSep) extra.push(`inner_sep="${node.innerSep}"`);
-    if (node.outerSep) extra.push(`outer_sep="${node.outerSep}"`);
-    if (node.nodeLineWidth) extra.push(`line_width="${node.nodeLineWidth}"`);
-    if (node.font) extra.push(`font="${node.font}"`);
-    if (node.textWidth) extra.push(`text_width="${node.textWidth}"`);
-    if (node.align) extra.push(`align="${node.align}"`);
-    if (node.anchor) extra.push(`anchor="${node.anchor}"`);
-    if (node.rotate != null) extra.push(`rotate=${node.rotate}`);
-    if (node.xshift) extra.push(`xshift="${node.xshift}"`);
-    if (node.yshift) extra.push(`yshift="${node.yshift}"`);
-    if (node.scale != null) extra.push(`scale=${node.scale}`);
-    if (node.roundedCorners) extra.push(`rounded_corners="${node.roundedCorners}"`);
-    if (node.doubleBorder) extra.push(`double="none"`);
-    if (node.dashPattern) extra.push(`dash_pattern="${node.dashPattern}"`);
-    if (node.pattern) extra.push(`pattern="${node.pattern}"`);
-    if (node.shading) extra.push(`shading="${node.shading}"`);
-    const extraStr = extra.length ? ', ' + extra.join(', ') : '';
-    lines.push(`fig.add_node(x=${cx}, y=${cy}, label="${node.id}", content="${node.label}"${fillArg}${drawArg}${shapeArg}${textArg}, minimum_width="${mw}", minimum_height="${mh}"${extraStr})`);
-  });
+  // Group items by layer
+  const hasMultipleLayers = state.layers.length > 1;
+  const usedLayers = new Set();
+  state.nodes.forEach(n => usedLayers.add(n.layer));
+  state.paths.forEach(p => usedLayers.add(p.layer));
+  const multiLayer = usedLayers.size > 1;
 
-  if (state.edges.length) {
-    lines.push(''); lines.push('# Add edges');
-    state.edges.forEach(edge => {
-      const arrowOpt = arrowToTikz(edge.arrow);
-      const colorArg = edge.color ? `, color="${cssColorToLatex(edge.color)}"` : '';
-      const lwArg = `, line_width="${edge.lineWidth}pt"`;
-      const blArg = edge.bendLeft !== 0 ? `, bend_left=${edge.bendLeft}` : '';
-      const brArg = edge.bendRight !== 0 ? `, bend_right=${edge.bendRight}` : '';
-      lines.push(`fig.draw(["${edge.sourceId}", "${edge.targetId}"]${colorArg}${lwArg}${blArg}${brArg}, options=["${arrowOpt}"])`);
+  if (multiLayer) {
+    // Render layer by layer
+    state.layers.forEach(layer => {
+      const layerNodes = state.nodes.filter(n => n.layer === layer.id);
+      const layerPaths = state.paths.filter(p => p.layer === layer.id);
+      if (!layerNodes.length && !layerPaths.length) return;
+
+      lines.push('');
+      lines.push(`# Layer: ${layer.name} (${layer.id})`);
+
+      if (layerNodes.length) {
+        layerNodes.forEach(node => {
+          const code = generateNodeCode(node);
+          // Add layer parameter
+          const insertPos = code.lastIndexOf(')');
+          lines.push(code.slice(0, insertPos) + `, layer=${layer.id}` + code.slice(insertPos));
+        });
+      }
+
+      if (layerPaths.length) {
+        layerPaths.forEach(p => {
+          const code = generatePathCode(p);
+          const insertPos = code.lastIndexOf(')');
+          lines.push(code.slice(0, insertPos) + `, layer=${layer.id}` + code.slice(insertPos));
+        });
+      }
     });
+  } else {
+    // Single layer — no layer parameter needed
+    if (state.nodes.length) {
+      lines.push(''); lines.push('# Add nodes');
+      state.nodes.forEach(node => lines.push(generateNodeCode(node)));
+    }
+
+    if (state.paths.length) {
+      lines.push(''); lines.push('# Add paths');
+      state.paths.forEach(p => lines.push(generatePathCode(p)));
+    }
+  }
+
+  // Raw TikZ
+  if (state.rawTikz.trim()) {
+    lines.push('');
+    lines.push('# Raw TikZ');
+    // Split into individual add_raw calls per line group
+    const rawLines = state.rawTikz.trim();
+    lines.push(`fig.add_raw("""${rawLines}""")`);
   }
 
   lines.push(''); lines.push('tikz_code = fig.generate_tikz()');
@@ -944,7 +1581,7 @@ function generateCode() {
 }
 
 async function runCodeGen() {
-  if (!state.pyodideReady || !state.nodes.length) return;
+  if (!state.pyodideReady || (!state.nodes.length && !state.rawTikz)) return;
   const pyCode = generatePythonCode();
   const fullCode = `
 import sys
@@ -974,8 +1611,9 @@ const tabState = {
     { id: 'props', label: 'Properties' },
     { id: 'code',  label: 'Code' },
     { id: 'pdf',   label: 'PDF' },
+    { id: 'layers', label: 'Layers' },
   ],
-  visible: new Set(['props', 'code', 'pdf']),
+  visible: new Set(['props', 'code', 'pdf', 'layers']),
   active: 'props',
 };
 
@@ -983,6 +1621,7 @@ function switchTab(id) {
   if (!tabState.visible.has(id)) tabState.visible.add(id);
   tabState.active = id;
   renderTabs();
+  if (id === 'layers') renderLayersPanel();
 }
 
 function renderTabs() {
@@ -1039,7 +1678,7 @@ document.getElementById('tab-bar').addEventListener('click', e => {
   }
   if (e.target.id === 'tab-restore-btn') { showRestoreMenu(e.target); return; }
   const btn = e.target.closest('.tab-btn[data-tab]');
-  if (btn) { tabState.active = btn.dataset.tab; renderTabs(); }
+  if (btn) { tabState.active = btn.dataset.tab; renderTabs(); if (btn.dataset.tab === 'layers') renderLayersPanel(); }
 });
 
 function showRestoreMenu(anchor) {
@@ -1085,6 +1724,15 @@ await micropip.install("tikzfigure")
 
 initPyodide();
 
+// ─── Raw TikZ Input ───────────────────────────────────────────────────────
+
+if (rawTikzInput) {
+  rawTikzInput.addEventListener('input', () => {
+    state.rawTikz = rawTikzInput.value;
+    upd();
+  });
+}
+
 // ─── Copy Helpers ──────────────────────────────────────────────────────────
 
 function copyCode(type) {
@@ -1101,15 +1749,29 @@ document.getElementById('btn-compile-toolbar').addEventListener('click', () => {
   else setStatus('No TikZ code ready \u2014 add nodes first.');
 });
 
+// ─── Export .tex ──────────────────────────────────────────────────────────
+
+document.getElementById('btn-export-tex')?.addEventListener('click', () => {
+  if (!state.standaloneLaTeX) {
+    setStatus('No LaTeX code ready. Add nodes and wait for Pyodide.');
+    return;
+  }
+  const blob = new Blob([state.standaloneLaTeX], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'figure.tex';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+  setStatus('Downloaded figure.tex');
+});
+
 // ─── PDF Compilation ───────────────────────────────────────────────────────
 
 const compileLogDetails = document.getElementById('compile-log-details');
 const compileLog        = document.getElementById('compile-log');
-
-if (typeof pdfjsLib !== 'undefined') {
-  pdfjsLib.GlobalWorkerOptions.workerSrc =
-    'https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/build/pdf.worker.min.js';
-}
 
 function showLog(text, hasError) {
   if (!text) { compileLogDetails.style.display = 'none'; return; }
@@ -1125,25 +1787,6 @@ function showLog(text, hasError) {
 }
 
 function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
-
-async function renderPdfToCanvas(buf) {
-  if (typeof pdfjsLib === 'undefined') return false;
-  try {
-    const pdf = await pdfjsLib.getDocument({ data: buf }).promise;
-    const page = await pdf.getPage(1);
-    const cw = pdfCanvas.parentElement?.clientWidth || 280;
-    const vp = page.getViewport({ scale: 1 });
-    const scale = (cw - 2) / vp.width;
-    const sv = page.getViewport({ scale });
-    pdfCanvas.width = sv.width; pdfCanvas.height = sv.height;
-    pdfCanvas.style.display = 'block';
-    await page.render({ canvasContext: pdfCanvas.getContext('2d'), viewport: sv }).promise;
-    return true;
-  } catch (err) {
-    console.error('PDF.js error:', err);
-    return false;
-  }
-}
 
 compileBtn.addEventListener('click', async () => {
   if (!state.standaloneLaTeX) { setStatus('No LaTeX to compile.'); return; }
@@ -1163,11 +1806,12 @@ compileBtn.addEventListener('click', async () => {
 
     if (resp.status === 201) {
       const buf = await resp.arrayBuffer();
-      await renderPdfToCanvas(buf);
       if (state._prevPdfUrl) URL.revokeObjectURL(state._prevPdfUrl);
       const blob = new Blob([buf], { type: 'application/pdf' });
       const url = URL.createObjectURL(blob);
       state._prevPdfUrl = url;
+      pdfViewer.src = url;
+      pdfViewer.style.display = 'block';
       pdfDl.href = url;
       pdfDl.style.display = 'inline-block';
       setStatus('PDF compiled successfully.');
@@ -1188,6 +1832,237 @@ compileBtn.addEventListener('click', async () => {
   }
 });
 
+// ─── Theme Toggle ─────────────────────────────────────────────────────────
+
+function toggleTheme() {
+  const isLight = document.body.classList.toggle('light');
+  document.getElementById('theme-icon-dark').style.display = isLight ? 'none' : '';
+  document.getElementById('theme-icon-light').style.display = isLight ? '' : 'none';
+  const dot = document.querySelector('#grid-dots circle');
+  if (dot) dot.setAttribute('fill', isLight ? '#d0d1d9' : '#282d3e');
+  localStorage.setItem('tikz-editor-theme', isLight ? 'light' : 'dark');
+}
+
+document.getElementById('btn-theme').onclick = toggleTheme;
+
+if (localStorage.getItem('tikz-editor-theme') === 'light') toggleTheme();
+
+// ─── Template Gallery ─────────────────────────────────────────────────────
+
+const TEMPLATES = [
+  {
+    name: 'Simple Graph',
+    desc: 'Nodes connected with arrows',
+    preview: '<svg viewBox="0 0 120 50"><circle cx="20" cy="25" r="8" fill="none" stroke="#818cf8" stroke-width="1.5"/><circle cx="60" cy="25" r="8" fill="none" stroke="#818cf8" stroke-width="1.5"/><circle cx="100" cy="25" r="8" fill="none" stroke="#818cf8" stroke-width="1.5"/><line x1="28" y1="25" x2="50" y2="25" stroke="#666" stroke-width="1.2" marker-end="url(#tpl-arrow)"/><line x1="68" y1="25" x2="90" y2="25" stroke="#666" stroke-width="1.2" marker-end="url(#tpl-arrow)"/><text x="20" y="28" text-anchor="middle" fill="#818cf8" font-size="8">A</text><text x="60" y="28" text-anchor="middle" fill="#818cf8" font-size="8">B</text><text x="100" y="28" text-anchor="middle" fill="#818cf8" font-size="8">C</text></svg>',
+    nodes: [
+      { x: 200, y: 260, label: 'A' },
+      { x: 400, y: 260, label: 'B' },
+      { x: 600, y: 260, label: 'C' },
+    ],
+    paths: [
+      { ni: [0, 1], arrow: 'stealth' },
+      { ni: [1, 2], arrow: 'stealth' },
+    ],
+  },
+  {
+    name: 'Triangle',
+    desc: 'Cycled path with fill',
+    preview: '<svg viewBox="0 0 120 70"><polygon points="60,8 20,58 100,58" fill="rgba(129,140,248,0.15)" stroke="#818cf8" stroke-width="1.5"/><circle cx="60" cy="8" r="4" fill="#818cf8"/><circle cx="20" cy="58" r="4" fill="#818cf8"/><circle cx="100" cy="58" r="4" fill="#818cf8"/></svg>',
+    nodes: [
+      { x: 400, y: 160, label: 'A' },
+      { x: 240, y: 400, label: 'B' },
+      { x: 560, y: 400, label: 'C' },
+    ],
+    paths: [
+      { ni: [0, 1, 2], cycle: true, fill: '#334488' },
+    ],
+  },
+  {
+    name: 'Flowchart',
+    desc: 'Decision flow with shapes',
+    preview: '<svg viewBox="0 0 120 70"><rect x="42" y="2" width="36" height="16" rx="8" fill="none" stroke="#818cf8" stroke-width="1.2"/><rect x="42" y="26" width="36" height="16" fill="none" stroke="#818cf8" stroke-width="1.2"/><polygon points="60,48 78,58 60,68 42,58" fill="none" stroke="#818cf8" stroke-width="1.2"/><line x1="60" y1="18" x2="60" y2="26" stroke="#666" stroke-width="1" marker-end="url(#tpl-arrow)"/><line x1="60" y1="42" x2="60" y2="48" stroke="#666" stroke-width="1" marker-end="url(#tpl-arrow)"/></svg>',
+    nodes: [
+      { x: 400, y: 120, label: 'Start', shape: 'ellipse', fill: '#1a3a2a' },
+      { x: 400, y: 260, label: 'Process', shape: 'rectangle', minWidth: 80, minHeight: 40 },
+      { x: 400, y: 420, label: '?', shape: 'diamond', minWidth: 60, minHeight: 60 },
+      { x: 600, y: 420, label: 'Yes' },
+      { x: 200, y: 420, label: 'No' },
+    ],
+    paths: [
+      { ni: [0, 1], arrow: 'stealth' },
+      { ni: [1, 2], arrow: 'stealth' },
+      { ni: [2, 3], arrow: 'stealth' },
+      { ni: [2, 4], arrow: 'stealth' },
+    ],
+  },
+  {
+    name: 'Network',
+    desc: 'Interconnected nodes',
+    preview: '<svg viewBox="0 0 120 70"><circle cx="25" cy="18" r="6" fill="none" stroke="#818cf8" stroke-width="1.2"/><circle cx="95" cy="18" r="6" fill="none" stroke="#818cf8" stroke-width="1.2"/><circle cx="25" cy="52" r="6" fill="none" stroke="#818cf8" stroke-width="1.2"/><circle cx="95" cy="52" r="6" fill="none" stroke="#818cf8" stroke-width="1.2"/><line x1="31" y1="18" x2="89" y2="18" stroke="#666" stroke-width="1"/><line x1="25" y1="24" x2="25" y2="46" stroke="#666" stroke-width="1"/><line x1="95" y1="24" x2="95" y2="46" stroke="#666" stroke-width="1"/><line x1="31" y1="52" x2="89" y2="52" stroke="#666" stroke-width="1"/><line x1="31" y1="22" x2="89" y2="48" stroke="#666" stroke-width="1" stroke-dasharray="3 2"/></svg>',
+    nodes: [
+      { x: 220, y: 180, label: 'A' },
+      { x: 540, y: 180, label: 'B' },
+      { x: 220, y: 380, label: 'C' },
+      { x: 540, y: 380, label: 'D' },
+    ],
+    paths: [
+      { ni: [0, 1] },
+      { ni: [0, 2] },
+      { ni: [1, 3] },
+      { ni: [2, 3] },
+      { ni: [0, 3], dashPattern: 'dashed' },
+    ],
+  },
+  {
+    name: 'State Machine',
+    desc: 'States with labeled transitions',
+    preview: '<svg viewBox="0 0 120 60"><circle cx="30" cy="30" r="12" fill="none" stroke="#818cf8" stroke-width="1.5"/><circle cx="90" cy="30" r="12" fill="none" stroke="#818cf8" stroke-width="1.5"/><line x1="42" y1="26" x2="76" y2="26" stroke="#666" stroke-width="1.2" marker-end="url(#tpl-arrow)"/><line x1="78" y1="34" x2="42" y2="34" stroke="#666" stroke-width="1.2" marker-end="url(#tpl-arrow)"/><text x="30" y="33" text-anchor="middle" fill="#818cf8" font-size="7">S0</text><text x="90" y="33" text-anchor="middle" fill="#818cf8" font-size="7">S1</text></svg>',
+    nodes: [
+      { x: 200, y: 280, label: 'S0', fill: '#1a2e3a' },
+      { x: 500, y: 280, label: 'S1', fill: '#1a2e3a' },
+      { x: 500, y: 440, label: 'S2', fill: '#1a2e3a' },
+    ],
+    paths: [
+      { ni: [0, 1], arrow: 'stealth' },
+      { ni: [1, 2], arrow: 'stealth' },
+      { ni: [2, 0], arrow: 'stealth', dashPattern: 'dashed' },
+    ],
+  },
+  {
+    name: 'Binary Tree',
+    desc: 'Hierarchical tree structure',
+    preview: '<svg viewBox="0 0 120 70"><circle cx="60" cy="10" r="6" fill="none" stroke="#818cf8" stroke-width="1.2"/><circle cx="30" cy="38" r="6" fill="none" stroke="#818cf8" stroke-width="1.2"/><circle cx="90" cy="38" r="6" fill="none" stroke="#818cf8" stroke-width="1.2"/><circle cx="15" cy="60" r="5" fill="none" stroke="#818cf8" stroke-width="1"/><circle cx="45" cy="60" r="5" fill="none" stroke="#818cf8" stroke-width="1"/><line x1="55" y1="15" x2="34" y2="33" stroke="#666" stroke-width="1"/><line x1="65" y1="15" x2="86" y2="33" stroke="#666" stroke-width="1"/><line x1="26" y1="43" x2="18" y2="55" stroke="#666" stroke-width="1"/><line x1="34" y1="43" x2="42" y2="55" stroke="#666" stroke-width="1"/></svg>',
+    nodes: [
+      { x: 400, y: 120, label: '1' },
+      { x: 260, y: 260, label: '2' },
+      { x: 540, y: 260, label: '3' },
+      { x: 190, y: 400, label: '4' },
+      { x: 330, y: 400, label: '5' },
+      { x: 470, y: 400, label: '6' },
+      { x: 610, y: 400, label: '7' },
+    ],
+    paths: [
+      { ni: [0, 1] },
+      { ni: [0, 2] },
+      { ni: [1, 3] },
+      { ni: [1, 4] },
+      { ni: [2, 5] },
+      { ni: [2, 6] },
+    ],
+  },
+  {
+    name: 'Neural Network',
+    desc: 'Layered network diagram',
+    preview: '<svg viewBox="0 0 120 70"><circle cx="20" cy="18" r="5" fill="none" stroke="#818cf8" stroke-width="1"/><circle cx="20" cy="35" r="5" fill="none" stroke="#818cf8" stroke-width="1"/><circle cx="20" cy="52" r="5" fill="none" stroke="#818cf8" stroke-width="1"/><circle cx="60" cy="24" r="5" fill="none" stroke="#f59e0b" stroke-width="1"/><circle cx="60" cy="46" r="5" fill="none" stroke="#f59e0b" stroke-width="1"/><circle cx="100" cy="35" r="5" fill="none" stroke="#6ee7b7" stroke-width="1"/><line x1="25" y1="18" x2="55" y2="24" stroke="#666" stroke-width="0.7"/><line x1="25" y1="18" x2="55" y2="46" stroke="#666" stroke-width="0.7"/><line x1="25" y1="35" x2="55" y2="24" stroke="#666" stroke-width="0.7"/><line x1="25" y1="35" x2="55" y2="46" stroke="#666" stroke-width="0.7"/><line x1="25" y1="52" x2="55" y2="24" stroke="#666" stroke-width="0.7"/><line x1="25" y1="52" x2="55" y2="46" stroke="#666" stroke-width="0.7"/><line x1="65" y1="24" x2="95" y2="35" stroke="#666" stroke-width="0.7"/><line x1="65" y1="46" x2="95" y2="35" stroke="#666" stroke-width="0.7"/></svg>',
+    nodes: [
+      { x: 160, y: 160, label: 'x1' },
+      { x: 160, y: 280, label: 'x2' },
+      { x: 160, y: 400, label: 'x3' },
+      { x: 380, y: 200, label: 'h1', draw: '#f59e0b' },
+      { x: 380, y: 340, label: 'h2', draw: '#f59e0b' },
+      { x: 600, y: 280, label: 'y', draw: '#6ee7b7' },
+    ],
+    paths: [
+      { ni: [0, 3] }, { ni: [0, 4] },
+      { ni: [1, 3] }, { ni: [1, 4] },
+      { ni: [2, 3] }, { ni: [2, 4] },
+      { ni: [3, 5], arrow: 'stealth' },
+      { ni: [4, 5], arrow: 'stealth' },
+    ],
+  },
+  {
+    name: 'Layered',
+    desc: 'Multi-layer demo (bg + fg)',
+    preview: '<svg viewBox="0 0 120 70"><rect x="10" y="10" width="100" height="50" rx="6" fill="rgba(129,140,248,0.1)" stroke="#818cf8" stroke-width="1" stroke-dasharray="3 2"/><circle cx="40" cy="35" r="10" fill="none" stroke="#f59e0b" stroke-width="1.5"/><circle cx="80" cy="35" r="10" fill="none" stroke="#6ee7b7" stroke-width="1.5"/><line x1="50" y1="35" x2="70" y2="35" stroke="#666" stroke-width="1.2" marker-end="url(#tpl-arrow)"/></svg>',
+    nodes: [
+      { x: 280, y: 260, label: 'A', draw: '#f59e0b', layer: 0 },
+      { x: 500, y: 260, label: 'B', draw: '#6ee7b7', layer: 0 },
+    ],
+    paths: [
+      { ni: [0, 1], arrow: 'stealth', layer: 0 },
+    ],
+    layers: [
+      { name: 'Background', items: 'bg' },
+      { name: 'Foreground', items: 'fg' },
+    ],
+    setup: (state) => {
+      // Add a second layer to demonstrate
+      if (state.layers.length === 1) {
+        state.layers.push({ id: state.nextLayerId++, name: 'Background', visible: true, locked: false });
+      }
+    },
+  },
+];
+
+function loadTemplate(tpl) {
+  saveHistory();
+  state.nodes = [];
+  state.paths = [];
+  state.nextNodeId = 1;
+  state.nextPathId = 1;
+
+  // Reset layers if template has custom setup
+  if (tpl.setup) tpl.setup(state);
+
+  tpl.nodes.forEach(n => {
+    const node = defaultNode(n.x, n.y);
+    if (n.label) node.label = n.label;
+    if (n.shape) node.shape = n.shape;
+    if (n.fill) node.fill = n.fill;
+    if (n.draw) node.draw = n.draw;
+    if (n.minWidth) node.minWidth = n.minWidth;
+    if (n.minHeight) node.minHeight = n.minHeight;
+    if (n.layer != null) node.layer = n.layer;
+    state.nodes.push(node);
+  });
+
+  tpl.paths.forEach(p => {
+    const nodeIds = p.ni.map(i => state.nodes[i].id);
+    const path = defaultPath(nodeIds);
+    if (p.arrow) path.arrow = p.arrow;
+    if (p.cycle) path.cycle = true;
+    if (p.fill) path.fill = p.fill;
+    if (p.dashPattern) path.dashPattern = p.dashPattern;
+    if (p.layer != null) path.layer = p.layer;
+    state.paths.push(path);
+  });
+
+  clearSelection();
+  hideTemplateGallery();
+  renderLayersPanel();
+  setStatus(`Loaded "${tpl.name}" template.`);
+}
+
+function showTemplateGallery() {
+  const el = document.getElementById('template-gallery');
+  el.classList.remove('hidden');
+  el.innerHTML = `
+    <div class="tpl-title">Start with a template</div>
+    <div class="tpl-subtitle">Or press N to add nodes manually</div>
+    <svg style="position:absolute;width:0;height:0">
+      <defs><marker id="tpl-arrow" markerWidth="6" markerHeight="5" refX="5" refY="2.5" orient="auto"><polygon points="0 0,6 2.5,0 5" fill="#666"/></marker></defs>
+    </svg>
+    <div class="tpl-grid">
+      ${TEMPLATES.map((t, i) => `
+        <button class="tpl-card" data-tpl="${i}">
+          ${t.preview}
+          <span class="tpl-card-name">${t.name}</span>
+          <span class="tpl-card-desc">${t.desc}</span>
+        </button>
+      `).join('')}
+    </div>
+  `;
+  el.querySelectorAll('.tpl-card').forEach(btn => {
+    btn.addEventListener('click', () => loadTemplate(TEMPLATES[parseInt(btn.dataset.tpl)]));
+  });
+}
+
+function hideTemplateGallery() {
+  document.getElementById('template-gallery').classList.add('hidden');
+}
+
 // ─── Init ──────────────────────────────────────────────────────────────────
 
 updateWorldTransform();
+renderLayersPanel();
+if (!state.nodes.length) showTemplateGallery();

--- a/astro_docs/public/tikz-editor.js
+++ b/astro_docs/public/tikz-editor.js
@@ -45,6 +45,7 @@ const pythonPre     = document.getElementById('python-code');
 const tikzPre       = document.getElementById('tikz-code');
 const compileBtn    = document.getElementById('compile-btn');
 const pdfViewer     = document.getElementById('pdf-viewer');
+const pdfDl         = document.getElementById('pdf-download');
 const pyodideStatus = document.getElementById('pyodide-status');
 const canvasResizer = document.getElementById('canvas-resizer');
 const contextMenu   = document.getElementById('context-menu');
@@ -54,6 +55,7 @@ const rawTikzInput  = document.getElementById('raw-tikz-input');
 const marqueeEl     = document.getElementById('selection-marquee');
 
 function setStatus(msg) { statusBar.textContent = msg; }
+function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
 
 // ─── Selection Helpers ────────────────────────────────────────────────────
 
@@ -937,6 +939,7 @@ document.addEventListener('keydown', (e) => {
 
   if (e.key === 'Enter' && state.mode === 'edge' && state.pathBuilder.length >= 2) { finishPath(false); return; }
   if (e.key === 'Escape' && state.mode === 'edge' && state.pathBuilder.length > 0) { cancelPath(); return; }
+  if (e.key === 'Escape') { const overlay = document.getElementById('compile-dialog-overlay'); if (overlay && overlay.style.display !== 'none') { closeCompileDialog(); return; } }
   if (e.key === 'v' || e.key === 'V') setMode('select');
   if (e.key === 'n' || e.key === 'N') setMode('node');
   if (e.key === 'e' || e.key === 'E') setMode('edge');
@@ -1287,7 +1290,7 @@ function renderLayersPanel() {
       <div class="layer-row${isActive ? ' active-layer' : ''}" data-layer-id="${l.id}">
         <button class="layer-vis-btn${l.visible ? '' : ' hidden-layer'}" data-vis="${l.id}" title="Toggle visibility">${l.visible ? '\u{1F441}' : '\u{1F441}\u200D\u{1F5E8}'}</button>
         <button class="layer-lock-btn${l.locked ? ' locked-layer' : ''}" data-lock="${l.id}" title="Toggle lock">${l.locked ? '\u{1F512}' : '\u{1F513}'}</button>
-        <span class="layer-name" data-rename="${l.id}">${l.name}</span>
+        <span class="layer-name">${l.name}</span>
         <span class="layer-count">${count}</span>
       </div>
     `;
@@ -1681,8 +1684,6 @@ async function runCompile(includedLayerIds) {
   setStatus('Sending to latex.ytotech.com\u2026');
   showLog('', false);
 
-  const pdfDl = document.getElementById('pdf-download');
-
   try {
     const resp = await fetch('https://latex.ytotech.com/builds/sync', {
       method: 'POST',
@@ -1815,8 +1816,6 @@ function showLog(text, hasError) {
   compileLogDetails.style.display = '';
   compileLogDetails.open = hasError;
 }
-
-function esc(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
 
 // ─── Theme Toggle ─────────────────────────────────────────────────────────
 

--- a/astro_docs/public/tikz-editor.js
+++ b/astro_docs/public/tikz-editor.js
@@ -46,8 +46,7 @@ const tikzPre       = document.getElementById('tikz-code');
 const compileBtn    = document.getElementById('compile-btn');
 const pdfViewer     = document.getElementById('pdf-viewer');
 const pyodideStatus = document.getElementById('pyodide-status');
-const resizer       = document.getElementById('resizer');
-const rightPanelEl  = document.getElementById('right-panel');
+const canvasResizer = document.getElementById('canvas-resizer');
 const contextMenu   = document.getElementById('context-menu');
 const zoomLabel     = document.getElementById('zoom-level');
 const layersPanel   = document.getElementById('layers-panel');
@@ -561,7 +560,6 @@ function selectNode(id, additive = false) {
   }
   updatePropertiesPanel();
   renderAll();
-  switchTab('props');
 }
 
 function selectPath(id, additive = false) {
@@ -572,7 +570,6 @@ function selectPath(id, additive = false) {
   }
   updatePropertiesPanel();
   renderAll();
-  switchTab('props');
 }
 
 function clearSelection() {
@@ -920,23 +917,8 @@ function setMode(mode) {
 document.getElementById('btn-select').onclick = () => setMode('select');
 document.getElementById('btn-add-node').onclick = () => setMode('node');
 document.getElementById('btn-add-edge').onclick = () => setMode('edge');
-document.getElementById('btn-delete').onclick = deleteSelected;
-document.getElementById('btn-duplicate').onclick = () => duplicateSelected();
 document.getElementById('btn-undo').onclick = undo;
 document.getElementById('btn-redo').onclick = redo;
-
-document.getElementById('btn-clear').onclick = () => {
-  if (!confirm('Clear all nodes and edges?')) return;
-  saveHistory();
-  state.nodes = []; state.paths = [];
-  state.nextNodeId = 1; state.nextPathId = 1;
-  state.rawTikz = '';
-  if (rawTikzInput) rawTikzInput.value = '';
-  clearSelection();
-  showTemplateGallery();
-  renderLayersPanel();
-  setStatus('Canvas cleared.');
-};
 
 // ─── Keyboard Shortcuts ────────────────────────────────────────────────────
 
@@ -963,20 +945,27 @@ document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') { setMode('select'); clearSelection(); hideContextMenu(); }
 });
 
-// ─── Resizer ───────────────────────────────────────────────────────────────
+// ─── Drawer Resize ─────────────────────────────────────────────────────────
 
-resizer.addEventListener('mousedown', (e) => {
+canvasResizer.addEventListener('mousedown', (e) => {
   e.preventDefault();
-  const startX = e.clientX;
-  const startWidth = rightPanelEl.offsetWidth;
-  const onMove = (ev) => rightPanelEl.style.width = `${Math.max(180, startWidth + (startX - ev.clientX))}px`;
+  const startY = e.clientY;
+  const drawer = document.getElementById('drawer');
+  const startH = drawer.offsetHeight;
+  const canvasCol = document.getElementById('canvas-column');
+
+  const onMove = (ev) => {
+    const delta = startY - ev.clientY;
+    const newH = Math.max(80, Math.min(canvasCol.offsetHeight - 200, startH + delta));
+    drawer.style.height = `${newH}px`;
+  };
   const onUp = () => {
     document.removeEventListener('mousemove', onMove);
     document.removeEventListener('mouseup', onUp);
     document.body.style.cursor = '';
     document.body.style.userSelect = '';
   };
-  document.body.style.cursor = 'col-resize';
+  document.body.style.cursor = 'row-resize';
   document.body.style.userSelect = 'none';
   document.addEventListener('mousemove', onMove);
   document.addEventListener('mouseup', onUp);
@@ -1604,100 +1593,24 @@ standalone_result = fig.generate_standalone()
   }
 }
 
-// ─── Tab System ────────────────────────────────────────────────────────────
+// ─── Drawer Section Switcher ───────────────────────────────────────────────
 
-const tabState = {
-  tabs: [
-    { id: 'props', label: 'Properties' },
-    { id: 'code',  label: 'Code' },
-    { id: 'pdf',   label: 'PDF' },
-    { id: 'layers', label: 'Layers' },
-  ],
-  visible: new Set(['props', 'code', 'pdf', 'layers']),
-  active: 'props',
-};
+const drawerState = { section: 'code' };
 
-function switchTab(id) {
-  if (!tabState.visible.has(id)) tabState.visible.add(id);
-  tabState.active = id;
-  renderTabs();
-  if (id === 'layers') renderLayersPanel();
-}
-
-function renderTabs() {
-  const tabBar = document.getElementById('tab-bar');
-  const visible = tabState.tabs.filter(t => tabState.visible.has(t.id));
-  const hidden  = tabState.tabs.filter(t => !tabState.visible.has(t.id));
-
-  if (tabState.active && !tabState.visible.has(tabState.active))
-    tabState.active = visible[0]?.id ?? null;
-
-  tabBar.innerHTML = visible.map(t => `
-    <button class="tab-btn${t.id === tabState.active ? ' active' : ''}" data-tab="${t.id}" draggable="true">
-      ${t.label}<span class="tab-hide-btn" data-hide="${t.id}">\u00d7</span>
-    </button>
-  `).join('') + (hidden.length ? '<button id="tab-restore-btn" title="Restore hidden tabs">+</button>' : '');
-
-  tabState.tabs.forEach(t => {
-    const pane = document.getElementById(`tab-pane-${t.id}`);
-    if (!pane) return;
-    const show = t.id === tabState.active;
-    pane.style.display = show ? 'flex' : 'none';
-    pane.classList.toggle('active-pane', show);
+function switchDrawerSection(section) {
+  drawerState.section = section;
+  document.querySelectorAll('.drawer-tab').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.section === section);
   });
-
-  tabBar.querySelectorAll('.tab-btn[draggable]').forEach(btn => {
-    const id = btn.dataset.tab;
-    btn.addEventListener('dragstart', e => { e.dataTransfer.setData('text/plain', id); btn.classList.add('dragging'); });
-    btn.addEventListener('dragend', () => btn.classList.remove('dragging'));
-    btn.addEventListener('dragover', e => { e.preventDefault(); btn.classList.add('drag-over'); });
-    btn.addEventListener('dragleave', () => btn.classList.remove('drag-over'));
-    btn.addEventListener('drop', e => {
-      e.preventDefault(); btn.classList.remove('drag-over');
-      const from = e.dataTransfer.getData('text/plain'), to = id;
-      if (from === to) return;
-      const fi = tabState.tabs.findIndex(t => t.id === from);
-      const ti = tabState.tabs.findIndex(t => t.id === to);
-      const [moved] = tabState.tabs.splice(fi, 1);
-      tabState.tabs.splice(ti, 0, moved);
-      renderTabs();
-    });
+  document.querySelectorAll('.drawer-section').forEach(el => {
+    el.style.display = el.id === `drawer-section-${section}` ? '' : 'none';
   });
 }
 
-document.getElementById('tab-bar').addEventListener('click', e => {
-  const hide = e.target.closest('[data-hide]');
-  if (hide) {
-    e.stopPropagation();
-    const id = hide.dataset.hide;
-    tabState.visible.delete(id);
-    if (tabState.active === id)
-      tabState.active = tabState.tabs.find(t => tabState.visible.has(t.id))?.id ?? null;
-    renderTabs();
-    return;
-  }
-  if (e.target.id === 'tab-restore-btn') { showRestoreMenu(e.target); return; }
-  const btn = e.target.closest('.tab-btn[data-tab]');
-  if (btn) { tabState.active = btn.dataset.tab; renderTabs(); if (btn.dataset.tab === 'layers') renderLayersPanel(); }
+document.getElementById('drawer-tabs').addEventListener('click', (e) => {
+  const btn = e.target.closest('.drawer-tab');
+  if (btn) switchDrawerSection(btn.dataset.section);
 });
-
-function showRestoreMenu(anchor) {
-  document.getElementById('tab-restore-menu')?.remove();
-  const hidden = tabState.tabs.filter(t => !tabState.visible.has(t.id));
-  if (!hidden.length) return;
-  const menu = document.createElement('div');
-  menu.id = 'tab-restore-menu';
-  hidden.forEach(tab => {
-    const b = document.createElement('button');
-    b.textContent = tab.label;
-    b.onclick = ev => { ev.stopPropagation(); tabState.visible.add(tab.id); tabState.active = tab.id; renderTabs(); menu.remove(); };
-    menu.appendChild(b);
-  });
-  document.getElementById('tab-bar').appendChild(menu);
-  setTimeout(() => document.addEventListener('click', () => menu.remove(), { once: true }), 0);
-}
-
-renderTabs();
 
 // ─── Pyodide ───────────────────────────────────────────────────────────────
 

--- a/astro_docs/src/content/docs/index.mdx
+++ b/astro_docs/src/content/docs/index.mdx
@@ -13,7 +13,7 @@ hero:
       variant: minimal
 ---
 
-[▶️ Try Tikzfigure in your browser (Pyodide Demo)](/pyodide-demo)
+[Try the Interactive TikZ Editor →](/tikzfigure/editor/)
 
 ---
 

--- a/docs/superpowers/specs/2026-04-13-tikz-editor-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-13-tikz-editor-redesign-design.md
@@ -1,0 +1,288 @@
+# TikZ Editor Redesign — Design Specification
+
+**Date:** 2026-04-13
+**Feature:** Redesign the browser editor into a more standard online drawing workspace
+**Scope:** `astro_docs/public/tikz-editor.html`, `astro_docs/public/tikz-editor.css`, `astro_docs/public/tikz-editor.js`
+
+---
+
+## Context
+
+The current TikZ editor already has the core interaction model needed for drawing:
+- a top toolbar with zoom, grid, snap, theme, compile, and export controls
+- a left tool rail for select / node / edge modes and editing actions
+- a large SVG canvas
+- a right-side panel with closable, draggable tabs for properties, code, PDF, and layers
+
+The main UX problem is the right-side tab system. It adds custom interaction overhead, consumes horizontal space, and makes the editor feel less like a standard design tool. The redesign should keep the existing editor engine and capabilities, but reshape the UI into a more familiar canvas-first layout.
+
+The user wants the redesign to optimize for visual drawing first, remove the closable-tab concept entirely, and move more global actions into the top bar.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+1. **Replace the closable right-side tab UI**
+   - Remove draggable, hideable, restorable tabs from the right side
+   - Eliminate the tab-management state and related controls in JavaScript
+   - Do not preserve the current "close tab / restore tab" interaction model in a new form
+
+2. **Adopt a standard drawing-app workspace**
+   - Keep the canvas as the primary visual focus
+   - Keep a left drawing toolbar for creation and mode switching
+   - Keep a stable right inspector for editing the current selection
+   - Introduce a bottom drawer for output-oriented tasks
+
+3. **Move global actions to the top bar**
+   - Top bar should host global or document-level controls such as compile/export, zoom/view, grid/snap, theme, and quick edit actions like undo/redo
+   - Controls should be grouped and visually clearer than the current compact strip
+
+4. **Preserve existing editor capabilities**
+   - Selection, dragging, multi-select, node creation, edge creation, duplication, deletion, layers, raw TikZ input, code generation, PDF compilation, and status messaging must continue to work
+   - Existing keyboard shortcuts should remain supported unless there is a clear collision created by the redesign
+
+5. **Provide stable output and preview surfaces**
+   - Python code, TikZ code, raw TikZ input, PDF preview, and compile log must still be available
+   - These surfaces should live in a bottom utility drawer rather than in right-side tabs
+
+### Non-Functional Requirements
+
+- The editor should feel more like a standard online drawing platform than a custom demo UI
+- The redesign should reduce horizontal competition with the canvas
+- The implementation should simplify UI state rather than re-creating tab complexity elsewhere
+- Existing rendering and generation logic should be reused instead of rewritten
+
+---
+
+## Recommended Approach
+
+Use a **canvas-first studio layout**:
+
+- **Top bar:** global actions and document controls
+- **Left rail:** tool modes and core editing tools
+- **Center workspace:** canvas
+- **Right inspector:** always-visible contextual properties and layers
+- **Bottom drawer:** code, raw TikZ, PDF preview, and compile log
+
+This is the best fit because it mirrors common drawing and diagramming tools, gives the canvas more usable width, and removes the bespoke tab UX without sacrificing existing features.
+
+Two alternatives were considered and rejected:
+
+1. **Single inspector workspace** — stack everything in the right panel. Simpler, but code/PDF still compete directly with drawing width.
+2. **Overlay utilities** — push outputs into modal or temporary overlays. Cleaner at rest, but weaker for edit-and-compare workflows.
+
+---
+
+## Design
+
+### 1. Layout Architecture
+
+The page should be reorganized into three major vertical bands:
+
+1. **Top application bar**
+2. **Main workspace**
+3. **Status bar**
+
+The main workspace should then be split into:
+
+1. **Left tool rail**
+2. **Canvas column**
+3. **Right inspector**
+
+The **canvas column** should contain:
+
+1. the canvas itself
+2. a resizable bottom drawer docked beneath it
+
+This changes the information flow from "canvas + tabbed sidecar" to "canvas + inspector + utility drawer", which is a more standard mental model for drawing tools.
+
+### 2. Top Bar Responsibilities
+
+The top bar should become the home for global controls:
+
+- brand/title
+- primary document actions
+  - compile to PDF
+  - export `.tex`
+- history and quick editing actions
+  - undo
+  - redo
+  - duplicate
+  - delete
+- view controls
+  - zoom out
+  - zoom level
+  - zoom in
+  - fit/reset
+- canvas toggles
+  - grid
+  - snap
+- theme toggle
+- Pyodide readiness indicator
+
+These should be grouped visually so the bar reads as a professional application header rather than a row of unrelated buttons.
+
+### 3. Left Tool Rail
+
+The left rail should stay focused and narrow. It should contain only the actions that define or directly support the drawing mode:
+
+- select / move
+- add node
+- draw path
+
+If undo/redo and destructive actions are moved into the top bar, the left rail can become cleaner and closer to the conventions of other drawing apps.
+
+### 4. Right Inspector
+
+The right panel should stop behaving like a tab host and become a stable inspector with stacked sections.
+
+Recommended section order:
+
+1. **Selection / Properties**
+   - show the current empty state when nothing is selected
+   - render the existing node/path property controls when there is a selection
+2. **Layers**
+   - show the layer list and layer actions beneath the selection editor
+
+This makes the right side a predictable editing surface rather than a place where unrelated tasks compete for the same slot.
+
+### 5. Bottom Drawer
+
+The bottom drawer should become the utility workspace for non-drawing tasks.
+
+Recommended sections inside the drawer:
+
+1. **Code**
+   - Python output
+   - TikZ output
+2. **Raw TikZ**
+   - verbatim input area
+3. **Preview**
+   - compile button
+   - PDF preview
+   - PDF download
+   - compile log
+
+The drawer may switch between sections, but this should be a lightweight docked control rather than a hideable right-side tab strip. It should be resizable and optionally collapsible, but not closable in the old sense.
+
+### 6. Empty States and Guidance
+
+The redesign should improve the idle experience:
+
+- Right inspector:
+  - explain that selecting a node or edge reveals editable properties
+- Bottom drawer:
+  - explain when code is not yet generated
+  - explain when PDF preview is unavailable because nothing has been compiled
+- Status bar:
+  - continue surfacing lightweight action feedback and shortcut hints
+
+These empty states should feel intentional and instructional, not like missing content.
+
+### 7. Visual Direction
+
+The CSS refresh should support the new workspace structure with:
+
+- stronger panel hierarchy
+- clearer grouping in the top bar
+- more deliberate spacing and section headers
+- less dense right-panel chrome
+- a more polished docked-drawer appearance
+
+The theme can stay close to the current dark/light palette, but the layout should feel more mature and less experimental.
+
+---
+
+## JavaScript and Markup Changes
+
+### HTML Changes
+
+Update the document structure to:
+
+- remove `#tab-bar` and all `tab-pane-*` wrappers
+- convert `#right-panel` into a persistent inspector shell
+- introduce a bottom drawer container in the canvas column
+- keep existing content anchors for properties, layers, code, raw TikZ, PDF viewer, and compile log where practical so existing JS renderers can be reused
+
+### JavaScript Changes
+
+Remove the tab system entirely:
+
+- delete `tabState`
+- delete `switchTab()`, `renderTabs()`, and restore-menu logic
+- remove tab-bar event handlers and drag/drop behavior
+
+Replace it with simpler UI state:
+
+- bottom drawer active section
+- bottom drawer collapsed / expanded state
+- bottom drawer height or resize state if resizing is implemented in JS
+
+Existing business logic should remain intact:
+
+- selection rendering still writes into the properties container
+- layer rendering still writes into the layers container
+- code generation still writes into the code containers
+- compile/export logic still targets the same functional controls
+
+The goal is to simplify layout coordination while preserving editor functionality.
+
+### CSS Changes
+
+The stylesheet should be reorganized around the new workspace primitives:
+
+- app bar
+- left rail
+- canvas column
+- right inspector
+- bottom drawer
+
+Tab-specific styles should be removed. New styles should support:
+
+- grouped top-bar controls
+- inspector section cards or panels
+- drawer header and section switcher
+- better responsive behavior on narrower screens
+
+---
+
+## Error Handling and Behavior Safety
+
+- Do not silently drop existing functionality during the redesign
+- If a control moves, preserve its behavior and keyboard shortcut
+- If the bottom drawer section is unavailable because content is not ready yet, show a clear empty state instead of a broken control
+- Keep the current compile readiness checks and status messages
+- Preserve the existing canvas, generation, and compilation flows unless a layout change requires explicit event rewiring
+
+---
+
+## Testing and Verification Expectations
+
+The implementation should verify:
+
+1. the new layout loads without missing-element JS errors
+2. selection still updates the inspector correctly
+3. layers still render and remain editable
+4. Python and TikZ output still appear in the drawer
+5. raw TikZ input still updates generated output
+6. compile/export actions still work from their new positions
+7. the removed tab system leaves no dead event handlers or broken references
+
+The emphasis is on preserving capabilities while simplifying the UI model.
+
+---
+
+## Implementation Notes
+
+- Prefer structural refactoring over incremental patching of the old tab layout
+- Reuse existing DOM IDs and renderer entry points when that reduces risk
+- Avoid introducing a new custom workspace manager that recreates the complexity being removed
+- Keep the redesign limited to the editor shell, styles, and UI wiring in the specified files
+
+---
+
+## Summary
+
+This redesign should turn the TikZ editor into a more standard online drawing workspace by removing the closable right-side tabs, moving global actions into a stronger top bar, keeping a stable right-side inspector, and relocating code/PDF/output tasks into a bottom drawer beneath the canvas. The implementation should simplify the UI state machine while preserving the editor's existing capabilities.

--- a/docs/superpowers/specs/2026-04-13-tikz-editor-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-13-tikz-editor-redesign-design.md
@@ -1,22 +1,21 @@
 # TikZ Editor Redesign — Design Specification
 
 **Date:** 2026-04-13
-**Feature:** Redesign the browser editor into a more standard online drawing workspace
+**Feature:** Redesign the browser editor into a Photoshop-style drawing workspace
 **Scope:** `astro_docs/public/tikz-editor.html`, `astro_docs/public/tikz-editor.css`, `astro_docs/public/tikz-editor.js`
 
 ---
 
 ## Context
 
-The current TikZ editor already has the core interaction model needed for drawing:
-- a top toolbar with zoom, grid, snap, theme, compile, and export controls
-- a left tool rail for select / node / edge modes and editing actions
-- a large SVG canvas
-- a right-side panel with closable, draggable tabs for properties, code, PDF, and layers
+The current TikZ editor has the core interaction model needed for drawing but its right-side panel uses closable, draggable, restorable tabs. This makes the editor feel like a custom demo UI rather than a standard drawing tool. The user has requested a redesign that:
 
-The main UX problem is the right-side tab system. It adds custom interaction overhead, consumes horizontal space, and makes the editor feel less like a standard design tool. The redesign should keep the existing editor engine and capabilities, but reshape the UI into a more familiar canvas-first layout.
-
-The user wants the redesign to optimize for visual drawing first, remove the closable-tab concept entirely, and move more global actions into the top bar.
+- removes the closable tab concept entirely
+- restructures panels to feel like Photoshop (stacked, always-visible, collapsible sections)
+- moves global actions into the top bar
+- puts code and PDF output in a bottom drawer beneath the canvas
+- adds a pre-flight layer selection dialog when compiling to PDF
+- adds a Layer assignment dropdown in the Properties section
 
 ---
 
@@ -24,265 +23,215 @@ The user wants the redesign to optimize for visual drawing first, remove the clo
 
 ### Functional Requirements
 
-1. **Replace the closable right-side tab UI**
-   - Remove draggable, hideable, restorable tabs from the right side
-   - Eliminate the tab-management state and related controls in JavaScript
-   - Do not preserve the current "close tab / restore tab" interaction model in a new form
+1. **Remove closable tab UI** — No tabs, no close/restore tab controls, no drag-to-reorder tabs.
 
-2. **Adopt a standard drawing-app workspace**
-   - Keep the canvas as the primary visual focus
-   - Keep a left drawing toolbar for creation and mode switching
-   - Keep a stable right inspector for editing the current selection
-   - Introduce a bottom drawer for output-oriented tasks
+2. **Right inspector: stacked collapsible cards** — The right panel is a single scrollable column with two collapsible section cards (Photoshop-style):
+   - **Properties** card — on top
+   - **Layers** card — below Properties
 
-3. **Move global actions to the top bar**
-   - Top bar should host global or document-level controls such as compile/export, zoom/view, grid/snap, theme, and quick edit actions like undo/redo
-   - Controls should be grouped and visually clearer than the current compact strip
+3. **Layer assignment in Properties** — When a node or edge is selected, the Properties card shows a "Layer" dropdown at the top of the property fields. Changing the dropdown moves the object to that layer.
 
-4. **Preserve existing editor capabilities**
-   - Selection, dragging, multi-select, node creation, edge creation, duplication, deletion, layers, raw TikZ input, code generation, PDF compilation, and status messaging must continue to work
-   - Existing keyboard shortcuts should remain supported unless there is a clear collision created by the redesign
+4. **Layers card shows object membership** — Each layer row in the Layers card shows a count badge (how many objects belong to that layer), plus the existing eye/lock toggle buttons. Add and Delete layer buttons appear at the bottom of the card.
 
-5. **Provide stable output and preview surfaces**
-   - Python code, TikZ code, raw TikZ input, PDF preview, and compile log must still be available
-   - These surfaces should live in a bottom utility drawer rather than in right-side tabs
+5. **Compile dialog for layer selection** — Clicking Compile PDF opens a modal dialog instead of immediately compiling. The dialog title is "Select layers to include in PDF." The body is a checkbox list of all current layers, all checked by default. Buttons: Cancel and Compile. The Compile button passes only the checked layers to the compile function.
+
+6. **Bottom drawer** — A docked, resizable drawer beneath the canvas. Three sections selectable via pill-style tabs at the drawer's top edge:
+   - **Code** — Python output and TikZ output (existing collapsible folds)
+   - **Raw TikZ** — verbatim textarea
+   - **Preview** — Compile PDF button (triggers the dialog), PDF viewer iframe, PDF download link, compile log
+
+7. **Top bar** — Houses all global/document-level controls. Left to right:
+   - Brand label
+   - Separator
+   - Compile PDF button (triggers dialog)
+   - Export TEX button
+   - Separator
+   - Undo, Redo
+   - Separator
+   - Zoom−, zoom level display, Zoom+, Fit
+   - Separator
+   - Grid toggle, Snap toggle
+   - Separator
+   - Theme toggle
+   - Pyodide status indicator (right-aligned)
+
+8. **Left rail** — Contains only the three drawing-mode buttons: Select, Add Node, Draw Path. Undo/Redo/Duplicate/Delete are removed from the rail (moved to top bar or accessible via keyboard/context menu).
+
+9. **Preserve existing capabilities** — Selection, dragging, multi-select, node/edge creation, duplication, deletion, raw TikZ input, code generation, PDF compilation, keyboard shortcuts, and status bar messaging must all continue to work.
 
 ### Non-Functional Requirements
 
-- The editor should feel more like a standard online drawing platform than a custom demo UI
-- The redesign should reduce horizontal competition with the canvas
-- The implementation should simplify UI state rather than re-creating tab complexity elsewhere
-- Existing rendering and generation logic should be reused instead of rewritten
+- The editor should feel like a professional drawing tool, not a demo
+- The right panel should feel structurally similar to Photoshop's docked panel system: dark chrome, clear section headers with a collapse triangle, no tab strip
+- The redesign should reduce UI state complexity (no tab state machine)
+- Existing rendering and generation logic should be reused, not rewritten
 
 ---
 
-## Recommended Approach
+## Layout Architecture
 
-Use a **canvas-first studio layout**:
-
-- **Top bar:** global actions and document controls
-- **Left rail:** tool modes and core editing tools
-- **Center workspace:** canvas
-- **Right inspector:** always-visible contextual properties and layers
-- **Bottom drawer:** code, raw TikZ, PDF preview, and compile log
-
-This is the best fit because it mirrors common drawing and diagramming tools, gives the canvas more usable width, and removes the bespoke tab UX without sacrificing existing features.
-
-Two alternatives were considered and rejected:
-
-1. **Single inspector workspace** — stack everything in the right panel. Simpler, but code/PDF still compete directly with drawing width.
-2. **Overlay utilities** — push outputs into modal or temporary overlays. Cleaner at rest, but weaker for edit-and-compare workflows.
-
----
-
-## Design
-
-### 1. Layout Architecture
-
-The page should be reorganized into three major vertical bands:
-
-1. **Top application bar**
-2. **Main workspace**
-3. **Status bar**
-
-The main workspace should then be split into:
-
-1. **Left tool rail**
-2. **Canvas column**
-3. **Right inspector**
-
-The **canvas column** should contain:
-
-1. the canvas itself
-2. a resizable bottom drawer docked beneath it
-
-This changes the information flow from "canvas + tabbed sidecar" to "canvas + inspector + utility drawer", which is a more standard mental model for drawing tools.
-
-### 2. Top Bar Responsibilities
-
-The top bar should become the home for global controls:
-
-- brand/title
-- primary document actions
-  - compile to PDF
-  - export `.tex`
-- history and quick editing actions
-  - undo
-  - redo
-  - duplicate
-  - delete
-- view controls
-  - zoom out
-  - zoom level
-  - zoom in
-  - fit/reset
-- canvas toggles
-  - grid
-  - snap
-- theme toggle
-- Pyodide readiness indicator
-
-These should be grouped visually so the bar reads as a professional application header rather than a row of unrelated buttons.
-
-### 3. Left Tool Rail
-
-The left rail should stay focused and narrow. It should contain only the actions that define or directly support the drawing mode:
-
-- select / move
-- add node
-- draw path
-
-If undo/redo and destructive actions are moved into the top bar, the left rail can become cleaner and closer to the conventions of other drawing apps.
-
-### 4. Right Inspector
-
-The right panel should stop behaving like a tab host and become a stable inspector with stacked sections.
-
-Recommended section order:
-
-1. **Selection / Properties**
-   - show the current empty state when nothing is selected
-   - render the existing node/path property controls when there is a selection
-2. **Layers**
-   - show the layer list and layer actions beneath the selection editor
-
-This makes the right side a predictable editing surface rather than a place where unrelated tasks compete for the same slot.
-
-### 5. Bottom Drawer
-
-The bottom drawer should become the utility workspace for non-drawing tasks.
-
-Recommended sections inside the drawer:
-
-1. **Code**
-   - Python output
-   - TikZ output
-2. **Raw TikZ**
-   - verbatim input area
-3. **Preview**
-   - compile button
-   - PDF preview
-   - PDF download
-   - compile log
-
-The drawer may switch between sections, but this should be a lightweight docked control rather than a hideable right-side tab strip. It should be resizable and optionally collapsible, but not closable in the old sense.
-
-### 6. Empty States and Guidance
-
-The redesign should improve the idle experience:
-
-- Right inspector:
-  - explain that selecting a node or edge reveals editable properties
-- Bottom drawer:
-  - explain when code is not yet generated
-  - explain when PDF preview is unavailable because nothing has been compiled
-- Status bar:
-  - continue surfacing lightweight action feedback and shortcut hints
-
-These empty states should feel intentional and instructional, not like missing content.
-
-### 7. Visual Direction
-
-The CSS refresh should support the new workspace structure with:
-
-- stronger panel hierarchy
-- clearer grouping in the top bar
-- more deliberate spacing and section headers
-- less dense right-panel chrome
-- a more polished docked-drawer appearance
-
-The theme can stay close to the current dark/light palette, but the layout should feel more mature and less experimental.
+```
+┌─────────────────────────────────────────────────────────────┐
+│  TOP BAR (brand · doc actions · edit · view · toggles)      │
+├────┬──────────────────────────────────┬─────────────────────┤
+│    │                                  │  RIGHT INSPECTOR    │
+│    │           CANVAS                 │  ┌───────────────┐  │
+│ L  │                                  │  │ ▾ Properties  │  │
+│ E  │                                  │  │   (fields)    │  │
+│ F  ├──────────────────────────────────┤  └───────────────┘  │
+│ T  │  BOTTOM DRAWER                   │  ┌───────────────┐  │
+│    │  [Code | Raw TikZ | Preview]     │  │ ▾ Layers      │  │
+│    │                                  │  │   (list)      │  │
+│    │                                  │  └───────────────┘  │
+├────┴──────────────────────────────────┴─────────────────────┤
+│  STATUS BAR                                                  │
+└─────────────────────────────────────────────────────────────┘
+```
 
 ---
 
-## JavaScript and Markup Changes
+## Detailed Component Design
 
-### HTML Changes
+### Top Bar
 
-Update the document structure to:
+Arranged left-to-right with visual separator elements between groups:
 
-- remove `#tab-bar` and all `tab-pane-*` wrappers
-- convert `#right-panel` into a persistent inspector shell
-- introduce a bottom drawer container in the canvas column
-- keep existing content anchors for properties, layers, code, raw TikZ, PDF viewer, and compile log where practical so existing JS renderers can be reused
+| Group | Controls |
+|---|---|
+| Brand | "TikZ Editor" label |
+| Document | Compile PDF, Export TEX |
+| Edit | Undo, Redo |
+| View | Zoom−, zoom%, Zoom+, Fit |
+| Canvas | Grid toggle, Snap toggle |
+| System | Theme toggle, Pyodide status |
 
-### JavaScript Changes
+### Left Rail
 
-Remove the tab system entirely:
+Three buttons only:
+- Select / Move (V)
+- Add Node (N)
+- Draw Path (E)
 
-- delete `tabState`
-- delete `switchTab()`, `renderTabs()`, and restore-menu logic
-- remove tab-bar event handlers and drag/drop behavior
+Duplicate, Delete, and Clear are removed from the left rail. They remain accessible via keyboard shortcuts (Ctrl+D, Del, etc.) and the right-click context menu. They are not added to the top bar.
 
-Replace it with simpler UI state:
+### Right Inspector
 
-- bottom drawer active section
-- bottom drawer collapsed / expanded state
-- bottom drawer height or resize state if resizing is implemented in JS
+A fixed-width (~280px) scrollable column. No tab bar. Two stacked section cards:
 
-Existing business logic should remain intact:
+**Properties card:**
+- Header: "Properties" with a collapse triangle (▾/▸). Starts expanded.
+- When nothing is selected: muted hint text "Select a node or edge to edit properties."
+- When an object is selected:
+  - Layer dropdown at the top: label "Layer", value = current layer name, options = all layer names
+  - Existing property fields (position, fill, stroke, shape, label, etc.) below the dropdown
+  - For multi-select: existing batch controls
 
-- selection rendering still writes into the properties container
-- layer rendering still writes into the layers container
-- code generation still writes into the code containers
-- compile/export logic still targets the same functional controls
+**Layers card:**
+- Header: "Layers" with a collapse triangle. Starts expanded.
+- Each layer row:
+  - Eye toggle button (visibility)
+  - Lock toggle button
+  - Layer name (editable on double-click)
+  - Object count badge (e.g., "3 objects")
+- Active layer highlighted
+- Bottom of card: "Add Layer" and "Delete Layer" buttons
 
-The goal is to simplify layout coordination while preserving editor functionality.
+### Bottom Drawer
 
-### CSS Changes
+Docked beneath the canvas. Resizable by dragging its top edge. Initial height: ~180px.
 
-The stylesheet should be reorganized around the new workspace primitives:
+Section switcher: three pill-style tabs at the top of the drawer — **Code**, **Raw TikZ**, **Preview**.
 
-- app bar
-- left rail
-- canvas column
-- right inspector
-- bottom drawer
+- **Code section:** Python output fold + TikZ output fold (existing collapsible `<details>` blocks with Copy buttons)
+- **Raw TikZ section:** verbatim textarea input
+- **Preview section:** Compile PDF button (triggers dialog), PDF viewer iframe, PDF download link, compile log details
 
-Tab-specific styles should be removed. New styles should support:
+The drawer is not closable.
 
-- grouped top-bar controls
-- inspector section cards or panels
-- drawer header and section switcher
-- better responsive behavior on narrower screens
+### Compile Dialog
 
----
+A modal overlay, triggered by any Compile PDF button (top bar or Preview section).
 
-## Error Handling and Behavior Safety
-
-- Do not silently drop existing functionality during the redesign
-- If a control moves, preserve its behavior and keyboard shortcut
-- If the bottom drawer section is unavailable because content is not ready yet, show a clear empty state instead of a broken control
-- Keep the current compile readiness checks and status messages
-- Preserve the existing canvas, generation, and compilation flows unless a layout change requires explicit event rewiring
-
----
-
-## Testing and Verification Expectations
-
-The implementation should verify:
-
-1. the new layout loads without missing-element JS errors
-2. selection still updates the inspector correctly
-3. layers still render and remain editable
-4. Python and TikZ output still appear in the drawer
-5. raw TikZ input still updates generated output
-6. compile/export actions still work from their new positions
-7. the removed tab system leaves no dead event handlers or broken references
-
-The emphasis is on preserving capabilities while simplifying the UI model.
+- **Title:** "Select layers to include in PDF"
+- **Body:** Checkbox list. One row per layer. All checked by default. Each row: `[✓] Layer name`.
+- **Footer buttons:** Cancel (dismisses dialog, no compile) | Compile (passes checked layers to compile function)
+- The compile function filters the TikZ output to only include `\pgfonlayer{name}` blocks for the checked layers before sending to the compile service.
 
 ---
 
-## Implementation Notes
+## JavaScript Changes
 
-- Prefer structural refactoring over incremental patching of the old tab layout
-- Reuse existing DOM IDs and renderer entry points when that reduces risk
-- Avoid introducing a new custom workspace manager that recreates the complexity being removed
-- Keep the redesign limited to the editor shell, styles, and UI wiring in the specified files
+### Remove
+- `tabState` object
+- `switchTab()`, `renderTabs()`, restore-menu logic
+- Tab drag/drop event handlers
+- All tab-hide and tab-restore button creation
+
+### Add
+- `drawerState`: `{ section: 'code'|'rawtikz'|'preview' }`
+- `drawerSectionSwitch(section)`: updates active pill and shows correct content
+- Drawer resize handler (drag the drawer's top edge)
+- `openCompileDialog()`: creates and shows the modal, populates with current layer names
+- `executeCompile(checkedLayers)`: filters TikZ output per selected layers, then calls existing compile logic
+- Layer assignment: `setObjectLayer(id, layerName)` — updates the object's layer, re-renders layer counts, regenerates code
+
+### Update
+- `renderProperties()`: add Layer dropdown at top of selection form; wire `change` event to `setObjectLayer`
+- `renderLayers()`: add object count badges per layer row
+- Existing compile/export entry points: route through `openCompileDialog()` instead of directly compiling
+
+### Preserve
+- All selection, drag, multi-select, canvas interaction logic
+- Code generation (`generateCode()`, `generate_tikz()`)
+- Export TEX logic
+- Keyboard shortcuts
+- Context menu
+- Status bar updates
+
+---
+
+## CSS Changes
+
+Remove tab-specific styles. Add:
+
+- **`.inspector-card`** — card wrapper for each right-panel section
+- **`.inspector-card-header`** — Photoshop-style section header: dark background, uppercase label, collapse triangle, full-width clickable
+- **`.inspector-card-body`** — content area, hidden when collapsed
+- **`.drawer`** — bottom drawer container
+- **`.drawer-tabs`** — pill tab switcher at drawer top
+- **`.drawer-section`** — each section's content container
+- **`.compile-dialog-overlay`** — full-screen modal backdrop
+- **`.compile-dialog`** — dialog card
+- **`.layer-count-badge`** — small count indicator on layer rows
+
+Retain the existing dark/light color token system (`--bg-*`, `--text-*`, `--accent`, etc.).
+
+---
+
+## Error Handling
+
+- If no layers exist when Compile dialog opens, show a single unchecked row "Default" as a fallback.
+- If all layers are unchecked in the dialog, disable the Compile button with a tooltip: "Select at least one layer."
+- If drawer resize would reduce canvas height below a usable minimum (~200px), clamp it.
+- Preserve existing compile error display (log + error highlighting) in the Preview section.
+
+---
+
+## Testing Checklist
+
+1. New layout loads without JS errors
+2. Properties card renders correctly for: nothing selected, node selected, edge selected, multi-select
+3. Layer dropdown in Properties correctly reassigns object to new layer
+4. Layers card shows correct object counts; counts update when objects move layers
+5. Compile dialog opens when Compile PDF is clicked; unchecking layers filters TikZ output correctly
+6. Bottom drawer section switching works; resize handle works; content persists across section switches
+7. Undo/Redo in top bar operates correctly
+8. All keyboard shortcuts still work
+9. No dead event handlers for removed tab system
+10. Light/dark theme toggle applies correctly to all new components
 
 ---
 
 ## Summary
 
-This redesign should turn the TikZ editor into a more standard online drawing workspace by removing the closable right-side tabs, moving global actions into a stronger top bar, keeping a stable right-side inspector, and relocating code/PDF/output tasks into a bottom drawer beneath the canvas. The implementation should simplify the UI state machine while preserving the editor's existing capabilities.
+The redesign restructures the TikZ editor as a Photoshop-style drawing workspace: a global top bar, a narrow left tool rail, a large canvas, a persistent right inspector with stacked collapsible Property and Layer cards, and a bottom utility drawer for code and PDF output. The closable-tab UX is removed entirely. PDF compilation gains a pre-flight layer selection dialog. Objects can be assigned to layers via a dropdown in the Properties card.


### PR DESCRIPTION
## Summary

- Replaces the closable/draggable tab panel system with Photoshop-style stacked collapsible inspector cards (Properties + Layers, always visible)
- Moves global actions (compile, export, undo/redo, zoom, grid/snap, theme) to the top bar; left rail reduced to 3 drawing-mode buttons only
- Adds a docked resizable bottom drawer (Code | Raw TikZ | Preview) in place of the old side panel
- Adds a pre-flight compile dialog: clicking PDF opens a modal with per-layer checkboxes, filtering `\pgfonlayer` blocks before sending to the compile service

## Test Plan
- [ ] Layout loads without JS errors — canvas, inspector cards, drawer all visible
- [ ] Properties card shows node/edge fields (including Layer dropdown) on selection
- [ ] Layers card shows object count badges; badge updates when layer assignment changes
- [ ] Clicking PDF in toolbar opens compile dialog with all layers checked
- [ ] Unchecking all layers disables the Compile button; Escape dismisses dialog
- [ ] Compile runs, drawer switches to Preview on completion, PDF appears
- [ ] Drawer Code / Raw TikZ / Preview tabs switch correctly
- [ ] Drawer resize handle adjusts height; canvas shrinks/grows accordingly
- [ ] Undo/Redo, keyboard shortcuts (V N E G Del Ctrl+Z), right-click context menu all work
- [ ] Light/dark theme toggle applies to all new components

🤖 Generated with [Claude Code](https://claude.com/claude-code)